### PR TITLE
APT-238: Added missing license headers, and appropriate checks added in CI

### DIFF
--- a/.github/workflows/check_license_headers.sh
+++ b/.github/workflows/check_license_headers.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Copyright 2022 Provizio Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+cd $(cd -P -- "$(dirname -- "$0")" && pwd -P)
+cd ../..
+
+# Use as check_license_header file_to_check comment_mark
+check_license_header() {
+    OUTPUT_PREFIX="Checking license header:"
+    FAILURE_PREFIX="License header is missing or invalid in"
+    FILE=$1
+    COMMENT_MARK=$2
+
+    echo "${OUTPUT_PREFIX} ${FILE}"
+    grep -q "${COMMENT_MARK} Copyright 2[0-9][0-9][0-9] Provizio Ltd." "${FILE}" || (echo "${FAILURE_PREFIX} ${FILE}"; exit 1)
+    grep -q "${COMMENT_MARK} Licensed under the Apache License, Version 2.0 (the \"License\");" "${FILE}" || (echo "${FAILURE_PREFIX} ${FILE}"; exit 1)
+}
+
+# .c/.cpp/.h/.hpp
+for FILE in $(find . -not \( -path ./build -prune \) -name '*.c' -or -name '*.cpp' -or -name '*.h' -or -name '*.hpp'); do
+    check_license_header "$FILE" "//"
+done
+
+# .sh
+for FILE in $(find . -not \( -path ./build -prune \) -name '*.sh'); do
+    check_license_header "$FILE" "#"
+done
+
+# .bat
+for FILE in $(find . -not \( -path ./build -prune \) -name '*.bat'); do
+    check_license_header "$FILE" "::"
+done
+
+echo "OK"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
   pull_request:
 
 jobs:
+  check-license-headers:
+    name: Check license headers
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: .github/workflows/check_license_headers.sh
+
   build-nix:
     name: Build provizio_radar_api_core with Static Code Analysis enabled
     runs-on: ${{matrix.runner}}

--- a/include/provizio/radar_api/errno.h
+++ b/include/provizio/radar_api/errno.h
@@ -1,3 +1,17 @@
+// Copyright 2022 Provizio Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef PROVIZIO_RADAR_API_ERRNO
 #define PROVIZIO_RADAR_API_ERRNO
 

--- a/src/core.c
+++ b/src/core.c
@@ -1,3 +1,17 @@
+// Copyright 2022 Provizio Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "provizio/radar_api/core.h"
 
 #include <string.h>

--- a/test/c_99/src/test_core.c
+++ b/test/c_99/src/test_core.c
@@ -1,3 +1,17 @@
+// Copyright 2022 Provizio Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "unity/unity.h"
 
 #include <pthread.h>

--- a/test/include/test_point_cloud_callbacks.h
+++ b/test/include/test_point_cloud_callbacks.h
@@ -1,3 +1,17 @@
+// Copyright 2022 Provizio Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef INCLUDE_TEST_POINT_CLOUD_CALLBACKS
 #define INCLUDE_TEST_POINT_CLOUD_CALLBACKS
 

--- a/test/include/unity_config.h
+++ b/test/include/unity_config.h
@@ -1,3 +1,17 @@
+// Copyright 2022 Provizio Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef INCLUDE_UNITY_CONFIG
 #define INCLUDE_UNITY_CONFIG
 


### PR DESCRIPTION
Fixing an issue: some license headers were missing, though they're required by our chose Apache License 2.0