### PR TITLE
APT-1140 correct float byte order and broadcasting

### DIFF
--- a/include/provizio/socket.h
+++ b/include/provizio/socket.h
@@ -77,9 +77,18 @@ PROVIZIO__EXTERN_C int32_t provizio_socket_close(PROVIZIO__SOCKET sock);
 /**
  * @brief Sets a timeout for recv operations on a previously opened socket
  *
+ * @param sock `socket`-returned socket object
  * @param timeout_ns Timeout in nanoseconds
  * @return 0 if successfull, error code otherwise
  */
 PROVIZIO__EXTERN_C int32_t provizio_socket_set_recv_timeout(PROVIZIO__SOCKET sock, uint64_t timeout_ns);
+
+/**
+ * @brief Permits for having multiple processes in the system to receive same UDP messages
+ *
+ * @param sock `socket`-returned socket object
+ * @return 0 if successfull, error code otherwise
+ */
+PROVIZIO__EXTERN_C int32_t provizio_socket_enable_address_and_port_reuse(PROVIZIO__SOCKET sock);
 
 #endif // PROVIZIO_SOCKET

--- a/src/core.c
+++ b/src/core.c
@@ -63,6 +63,25 @@ int32_t provizio_open_radars_connection(uint16_t udp_port, uint64_t receive_time
         }
     }
 
+    // Enable broadcasting support
+    const int broadcast = 1;
+    status = (int32_t)setsockopt(sock, SOL_SOCKET, SO_BROADCAST, (const char *)&broadcast, sizeof(broadcast));
+    if (status != 0)
+    {
+        // LCOV_EXCL_START: Can't be unit-tested as it depends on the state of the OS
+        provizio_warning("provizio_open_radars_connection: Enabling broadcasting failed!");
+        // LCOV_EXCL_STOP
+    }
+
+    // Enable address and port reuse, so multiple processes can receive same packets
+    status = provizio_socket_enable_address_and_port_reuse(sock);
+    if (status != 0)
+    {
+        // LCOV_EXCL_START: Can't be unit-tested as it depends on the state of the OS
+        provizio_warning("provizio_open_radars_connection: Enabling address & port reuse failed!");
+        // LCOV_EXCL_STOP
+    }
+
     struct sockaddr_in my_address;
     memset(&my_address, 0, sizeof(my_address));
     my_address.sin_family = AF_INET;
@@ -74,9 +93,11 @@ int32_t provizio_open_radars_connection(uint16_t udp_port, uint64_t receive_time
     status = (int32_t)bind(sock, (struct sockaddr *)&my_address, sizeof(my_address));
     if (status != 0)
     {
+        // LCOV_EXCL_START: Can't be unit-tested as it depends on the state of the OS
         provizio_error("provizio_open_radars_connection: Failed to bind a UDP socket!");
         provizio_socket_close(sock);
         return status;
+        // LCOV_EXCL_STOP
     }
 
     if (check_connection)

--- a/src/radar_point_cloud.c
+++ b/src/radar_point_cloud.c
@@ -271,8 +271,16 @@ int32_t provizio_handle_radar_point_cloud_packet_checked(provizio_radar_point_cl
         return PROVIZIO_E_PROTOCOL;
     }
 
-    memcpy(&cloud->radar_points[cloud->num_points_received], &packet->radar_points,
-           sizeof(provizio_radar_point) * num_points_in_packet);
+    for (uint16_t i = 0; i < num_points_in_packet; ++i)
+    {
+        provizio_radar_point *out_point = &cloud->radar_points[cloud->num_points_received + i];
+        provizio_radar_point *in_point = &packet->radar_points[i];
+        out_point->x_meters = provizio_get_protocol_field_float(&in_point->x_meters);
+        out_point->y_meters = provizio_get_protocol_field_float(&in_point->y_meters);
+        out_point->z_meters = provizio_get_protocol_field_float(&in_point->z_meters);
+        out_point->velocity_m_s = provizio_get_protocol_field_float(&in_point->velocity_m_s);
+        out_point->signal_to_noise_ratio = provizio_get_protocol_field_float(&in_point->signal_to_noise_ratio);
+    }
     cloud->num_points_received += num_points_in_packet;
 
     if (cloud->num_points_received == cloud->num_points_expected)

--- a/src/radar_point_cloud.c
+++ b/src/radar_point_cloud.c
@@ -20,6 +20,12 @@
 #include "provizio/radar_api/errno.h"
 #include "provizio/util.h"
 
+int provizio_network_floats_reversed()
+{
+    const float test_value = 1.0F;
+    return ((const char *)(&test_value))[3] != 0;
+}
+
 void provizio_return_point_cloud(provizio_radar_point_cloud_api_context *context,
                                  provizio_radar_point_cloud *point_cloud)
 {
@@ -271,16 +277,32 @@ int32_t provizio_handle_radar_point_cloud_packet_checked(provizio_radar_point_cl
         return PROVIZIO_E_PROTOCOL;
     }
 
-    for (uint16_t i = 0; i < num_points_in_packet; ++i)
+    // Append new points to the point cloud being received
+    if (!provizio_network_floats_reversed())
     {
-        provizio_radar_point *out_point = &cloud->radar_points[cloud->num_points_received + i];
-        provizio_radar_point *in_point = &packet->radar_points[i];
-        out_point->x_meters = provizio_get_protocol_field_float(&in_point->x_meters);
-        out_point->y_meters = provizio_get_protocol_field_float(&in_point->y_meters);
-        out_point->z_meters = provizio_get_protocol_field_float(&in_point->z_meters);
-        out_point->velocity_m_s = provizio_get_protocol_field_float(&in_point->velocity_m_s);
-        out_point->signal_to_noise_ratio = provizio_get_protocol_field_float(&in_point->signal_to_noise_ratio);
+        // Optimized version: host machine uses network byte order for floats, no need to convert them
+        // LCOV_EXCL_START: host CPU arch dependent
+        memcpy(&cloud->radar_points[cloud->num_points_received], &packet->radar_points,
+               sizeof(provizio_radar_point) * num_points_in_packet);
+        // LCOV_EXCL_STOP
     }
+    else
+    {
+        // Every value has to be converted to the host byte order
+        // LCOV_EXCL_START: host CPU arch dependent
+        for (uint16_t i = 0; i < num_points_in_packet; ++i)
+        {
+            provizio_radar_point *out_point = &cloud->radar_points[cloud->num_points_received + i];
+            provizio_radar_point *in_point = &packet->radar_points[i];
+            out_point->x_meters = provizio_get_protocol_field_float(&in_point->x_meters);
+            out_point->y_meters = provizio_get_protocol_field_float(&in_point->y_meters);
+            out_point->z_meters = provizio_get_protocol_field_float(&in_point->z_meters);
+            out_point->velocity_m_s = provizio_get_protocol_field_float(&in_point->velocity_m_s);
+            out_point->signal_to_noise_ratio = provizio_get_protocol_field_float(&in_point->signal_to_noise_ratio);
+        }
+        // LCOV_EXCL_STOP
+    }
+
     cloud->num_points_received += num_points_in_packet;
 
     if (cloud->num_points_received == cloud->num_points_expected)

--- a/src/socket.c
+++ b/src/socket.c
@@ -64,3 +64,17 @@ int32_t provizio_socket_set_recv_timeout(PROVIZIO__SOCKET sock, uint64_t timeout
 
     return status;
 }
+
+int32_t provizio_socket_enable_address_and_port_reuse(PROVIZIO__SOCKET sock)
+{
+    const int enable = 1;
+    int32_t status = (int32_t)setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (const char *)&enable, sizeof(enable));
+#ifndef _WIN32
+    if (status == 0)
+    {
+        status = (int32_t)setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, (const char *)&enable, sizeof(enable));
+    }
+#endif
+
+    return status;
+}

--- a/test/c_99/src/test_core.c
+++ b/test/c_99/src/test_core.c
@@ -847,21 +847,6 @@ static void test_receive_radar_point_cloud_timeout_fails(void)
     TEST_ASSERT_EQUAL_INT32(0, provizio_close_radar_connection(&connection));
 }
 
-static void test_provizio_radar_point_cloud_api_connect_fails_due_to_port_taken(void)
-{
-    const uint16_t port_number = 10010 + PROVIZIO__RADAR_API_DEFAULT_PORT;
-
-    provizio_radar_api_connection ok_connection;
-    provizio_radar_api_connection failed_connection;
-
-    TEST_ASSERT_EQUAL_INT32(0, provizio_open_radar_connection(port_number, 0, 0, NULL, &ok_connection));
-
-    provizio_set_on_error(&test_provizio_on_error);
-    TEST_ASSERT_NOT_EQUAL_INT32(0, provizio_open_radar_connection(port_number, 0, 0, NULL, &failed_connection));
-    TEST_ASSERT_EQUAL_STRING("provizio_open_radars_connection: Failed to bind a UDP socket!", provizio_test_error);
-    provizio_set_on_error(NULL);
-}
-
 static void test_provizio_radar_point_cloud_api_contexts_receive_packet_fails_as_not_connected(void)
 {
     provizio_radar_api_connection api_connetion;
@@ -1252,7 +1237,6 @@ int provizio_run_test_core(void)
     RUN_TEST(test_receive_radar_point_cloud_not_enough_contexts);
     RUN_TEST(test_receive_radar_point_cloud_timeout_ok);
     RUN_TEST(test_receive_radar_point_cloud_timeout_fails);
-    RUN_TEST(test_provizio_radar_point_cloud_api_connect_fails_due_to_port_taken);
     RUN_TEST(test_provizio_radar_point_cloud_api_contexts_receive_packet_fails_as_not_connected);
     RUN_TEST(test_provizio_radar_point_cloud_api_close_fails_as_not_connected);
     RUN_TEST(test_provizio_set_radar_mode_ok);

--- a/test/c_99/src/test_util.c
+++ b/test/c_99/src/test_util.c
@@ -102,21 +102,21 @@ static void test_provizio_set_protocol_field_float(void)
     uint8_t test_buffer[5]; // NOLINT
     memset(test_buffer, 0, sizeof(test_buffer));
 
-    const float test_float = 12.345F;
+    const float test_float = 1.0F;
 
     // Aligned write
     provizio_set_protocol_field_float((float *)&test_buffer[0], test_float);
-    float to_float = 0.0F;
-    memcpy(&to_float, &test_buffer[0], sizeof(float));
-    TEST_ASSERT_EQUAL(test_float, // NOLINT
-                      to_float);
+    TEST_ASSERT_EQUAL(0x3f, test_buffer[0]);
+    TEST_ASSERT_EQUAL(0x80, test_buffer[1]);
+    TEST_ASSERT_EQUAL(0x00, test_buffer[2]);
+    TEST_ASSERT_EQUAL(0x00, test_buffer[3]);
 
     // Unaligned write
     provizio_set_protocol_field_float((float *)&test_buffer[1], test_float);
-    to_float = 0.0F;
-    memcpy(&to_float, &test_buffer[1], sizeof(float));
-    TEST_ASSERT_EQUAL(test_float, // NOLINT
-                      to_float);
+    TEST_ASSERT_EQUAL(0x3f, test_buffer[1]);
+    TEST_ASSERT_EQUAL(0x80, test_buffer[2]);
+    TEST_ASSERT_EQUAL(0x00, test_buffer[3]);
+    TEST_ASSERT_EQUAL(0x00, test_buffer[4]);
 }
 
 static void test_provizio_get_protocol_field_uint8_t(void)
@@ -164,20 +164,18 @@ static void test_provizio_get_protocol_field_uint64_t(void)
 
 static void test_provizio_get_protocol_field_float(void)
 {
-    uint8_t test_buffer[5]; // NOLINT
-    memset(test_buffer, 0, sizeof(test_buffer));
+    uint8_t test_buffer_aligned[4] = {0x3f, 0x80, 0x00, 0x00};         // NOLINT
+    uint8_t test_buffer_unaligned[5] = {0x00, 0x3f, 0x80, 0x00, 0x00}; // NOLINT
 
-    const float test_float = 123.456F;
+    const float test_float = 1.0F;
 
     // Aligned read
-    memcpy(&test_buffer[0], &test_float, sizeof(float));
     TEST_ASSERT_EQUAL(test_float, // NOLINT
-                      provizio_get_protocol_field_float((float *)&test_buffer[0]));
+                      provizio_get_protocol_field_float((float *)&test_buffer_aligned[0]));
 
     // Unaligned read
-    memcpy(&test_buffer[1], &test_float, sizeof(float));
     TEST_ASSERT_EQUAL(test_float, // NOLINT
-                      provizio_get_protocol_field_float((float *)&test_buffer[1]));
+                      provizio_get_protocol_field_float((float *)&test_buffer_unaligned[1]));
 }
 
 static void test_provizio_gettimeofday(void)


### PR DESCRIPTION
Tested and working.
This PR fixes 2 issues found when working on live clustering:
- Floats byte order when sent over network was incorrect (and as a result incompatible with appropriate python implementation)
- Only one process in a machine could receive radar messages, which prevented APT GUI and live clustering/tracking to receive radar packets in the same time