### PR TITLE
Added ground_relative_radial_velocity_m_s to field radar point cloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 Testing/
 *.dump
 *.ctu-info
+.*swp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,16 @@
 # Copyright 2022 Provizio Ltd.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
 
 cmake_minimum_required(VERSION 3.1.0)
 
@@ -47,83 +47,95 @@ endif(CCACHE AND NOT CMAKE_C_COMPILER_LAUNCHER)
 # Format checking option is enabled by default
 if(NOT ENABLE_CHECK_FORMAT)
   set(ENABLE_CHECK_FORMAT
-        "ON"
-        CACHE STRING "Enable Format Checking")
+      "ON"
+      CACHE STRING "Enable Format Checking")
 endif(NOT ENABLE_CHECK_FORMAT)
 
 # Static analysis disabled by default
 if(NOT STATIC_ANALYSIS)
   set(STATIC_ANALYSIS
-        "OFF"
-        CACHE STRING "Enable Static Analysis")
+      "OFF"
+      CACHE STRING "Enable Static Analysis")
 endif(NOT STATIC_ANALYSIS)
 
 # Generating code coverage info is disabled by default
 if(NOT ENABLE_COVERAGE)
   set(ENABLE_COVERAGE
-        "OFF"
-        CACHE STRING "Enable Code Coverage Checks")
+      "OFF"
+      CACHE STRING "Enable Code Coverage Checks")
 endif(NOT ENABLE_COVERAGE)
 
 # Linux/macOS specific checks
 if(UNIX)
   # clang-tidy (use as clang-tidy;arguments)
   set(CMAKE_C_CLANG_TIDY
-    ""
-    CACHE STRING "clang-tidy binary and config (C)")
+      ""
+      CACHE STRING "clang-tidy binary and config (C)")
   set(CMAKE_CXX_CLANG_TIDY
-    ""
-    CACHE STRING "clang-tidy binary and config (C++)")
-  
+      ""
+      CACHE STRING "clang-tidy binary and config (C++)")
+
   # Automatically enable clang-tidy if STATIC_ANALYSIS is turned on
   if(NOT CMAKE_C_CLANG_TIDY AND STATIC_ANALYSIS)
     message(STATUS "STATIC_ANALYSIS is enabled. Turning on clang-tidy.")
     find_program(CLANG_TIDY_PATH clang-tidy)
     if(CLANG_TIDY_PATH)
       set(CMAKE_C_CLANG_TIDY
-        "${CLANG_TIDY_PATH}"
-        CACHE STRING "clang-tidy binary and config" FORCE)
+          "${CLANG_TIDY_PATH}"
+          CACHE STRING "clang-tidy binary and config" FORCE)
       set(CMAKE_CXX_CLANG_TIDY
-        "${CLANG_TIDY_PATH}"
-        CACHE STRING "clang-tidy binary and config" FORCE)
+          "${CLANG_TIDY_PATH}"
+          CACHE STRING "clang-tidy binary and config" FORCE)
     else(CLANG_TIDY_PATH)
       message("clang-tidy not found. Appropriate checks won't be done!")
     endif(CLANG_TIDY_PATH)
   endif()
-  
-  # Enable Format.cmake (forked from https://github.com/TheLartians/Format.cmake), if supported and enabled
+
+  # Enable Format.cmake (forked from
+  # https://github.com/TheLartians/Format.cmake), if supported and enabled
   if(ENABLE_CHECK_FORMAT)
-    execute_process(COMMAND clang-format --version OUTPUT_VARIABLE CLANG_FORMAT_VERSION)
+    execute_process(COMMAND clang-format --version
+                    OUTPUT_VARIABLE CLANG_FORMAT_VERSION)
     if(CLANG_FORMAT_VERSION)
       string(STRIP CLANG_FORMAT_VERSION "${CLANG_FORMAT_VERSION}")
       string(REPLACE "\n" "" CLANG_FORMAT_VERSION "${CLANG_FORMAT_VERSION}")
-      string(REPLACE "clang-format version " "" CLANG_FORMAT_VERSION "${CLANG_FORMAT_VERSION}")
-      string(REGEX MATCH "[^\.]*" CLANG_FORMAT_VERSION_MAJOR "${CLANG_FORMAT_VERSION}")
+      string(REPLACE "clang-format version " "" CLANG_FORMAT_VERSION
+                     "${CLANG_FORMAT_VERSION}")
+      string(REGEX MATCH "[^\.]*" CLANG_FORMAT_VERSION_MAJOR
+                   "${CLANG_FORMAT_VERSION}")
     endif(CLANG_FORMAT_VERSION)
     if(CLANG_FORMAT_VERSION_MAJOR AND NOT CLANG_FORMAT_VERSION_MAJOR LESS 10)
-      message("Compatible version of clang-format found: ${CLANG_FORMAT_VERSION}")
+      message(
+        "Compatible version of clang-format found: ${CLANG_FORMAT_VERSION}")
       set(FORMAT_CMAKE_PATH
           "${CMAKE_BINARY_DIR}/Format.cmake-${FORMAT_CMAKE_VERSION}")
       if(NOT EXISTS "${FORMAT_CMAKE_PATH}")
         set(FORMAT_CMAKE_DOWNLOAD_URL
             "https://github.com/provizio/Format.cmake/archive/refs/tags/v${FORMAT_CMAKE_VERSION}.tar.gz"
         )
-        file(DOWNLOAD "${FORMAT_CMAKE_DOWNLOAD_URL}" "${FORMAT_CMAKE_PATH}.tar.gz" TLS_VERIFY ${TLS_VERIFY})
+        file(DOWNLOAD "${FORMAT_CMAKE_DOWNLOAD_URL}"
+             "${FORMAT_CMAKE_PATH}.tar.gz" TLS_VERIFY ${TLS_VERIFY})
         execute_process(COMMAND tar -xf "${FORMAT_CMAKE_PATH}.tar.gz" -C
                                 "${CMAKE_BINARY_DIR}")
       endif(NOT EXISTS "${FORMAT_CMAKE_PATH}")
-      set(FORMAT_SKIP_CMAKE YES CACHE BOOL "" FORCE)
+      set(FORMAT_SKIP_CMAKE
+          YES
+          CACHE BOOL "" FORCE)
       add_subdirectory("${FORMAT_CMAKE_PATH}" EXCLUDE_FROM_ALL)
-    
+
       # Automatically enable clang-format checks if STATIC_ANALYSIS is turned on
       if(STATIC_ANALYSIS)
-        message(STATUS "STATIC_ANALYSIS is enabled. Adding check-format to ALL.")
+        message(
+          STATUS "STATIC_ANALYSIS is enabled. Adding check-format to ALL.")
         add_custom_target(check-format-all ALL DEPENDS check-format)
       endif(STATIC_ANALYSIS)
     else(CLANG_FORMAT_VERSION_MAJOR AND NOT CLANG_FORMAT_VERSION_MAJOR LESS 10)
-      if (CLANG_FORMAT_VERSION)
+      if(CLANG_FORMAT_VERSION)
         # clang-format is too old
-        message(WARNING "clang-format version ${CLANG_FORMAT_VERSION} is not supported. Format checks won't be done!")
+        message(
+          WARNING
+            "clang-format version ${CLANG_FORMAT_VERSION} is not supported. Format checks won't be done!"
+        )
       else(CLANG_FORMAT_VERSION)
         # clang-format is missing
         message(WARNING "clang-format is missing. Format checks won't be done!")
@@ -134,30 +146,52 @@ if(UNIX)
   # cppcheck
   find_program(CPPCHECK_PATH cppcheck)
   if(CPPCHECK_PATH)
-    execute_process(COMMAND "${CPPCHECK_PATH}" --version OUTPUT_VARIABLE CPPCHECK_VERSION)
+    execute_process(COMMAND "${CPPCHECK_PATH}" --version
+                    OUTPUT_VARIABLE CPPCHECK_VERSION)
     string(STRIP CPPCHECK_VERSION "${CPPCHECK_VERSION}")
     string(REPLACE "\n" "" CPPCHECK_VERSION "${CPPCHECK_VERSION}")
     string(REPLACE "Cppcheck " "" CPPCHECK_VERSION "${CPPCHECK_VERSION}")
     if(NOT "${CPPCHECK_VERSION}" VERSION_LESS "1.90")
-      message("Compatible version of cppcheck found: ${CPPCHECK_VERSION}. Adding target cppcheck-misra.")
-      add_custom_target(cppcheck-misra "${CPPCHECK_PATH}" --enable=all --inline-suppr --check-config --suppress=missingIncludeSystem --dump --addon=misra.py --project="${CMAKE_BINARY_DIR}/compile_commands.json")
+      message(
+        "Compatible version of cppcheck found: ${CPPCHECK_VERSION}. Adding target cppcheck-misra."
+      )
+      add_custom_target(
+        cppcheck-misra
+        "${CPPCHECK_PATH}"
+        --enable=all
+        --inline-suppr
+        --check-config
+        --suppress=missingIncludeSystem
+        --dump
+        --addon=misra.py
+        --project="${CMAKE_BINARY_DIR}/compile_commands.json")
       # Automatically enable cppcheck-misra if STATIC_ANALYSIS is turned on
       if(STATIC_ANALYSIS)
-        message(STATUS "STATIC_ANALYSIS is enabled. Adding cppcheck-misra to ALL.")
+        message(
+          STATUS "STATIC_ANALYSIS is enabled. Adding cppcheck-misra to ALL.")
         add_custom_target(cppcheck-misra-all ALL DEPENDS cppcheck-misra)
       endif(STATIC_ANALYSIS)
     else(NOT "${CPPCHECK_VERSION}" VERSION_LESS "1.90")
-      message(WARNING "Unsupported version of cppcheck: ${CPPCHECK_VERSION}. cppcheck-misra target won't be added.")
+      message(
+        WARNING
+          "Unsupported version of cppcheck: ${CPPCHECK_VERSION}. cppcheck-misra target won't be added."
+      )
     endif(NOT "${CPPCHECK_VERSION}" VERSION_LESS "1.90")
   else(CPPCHECK_PATH)
     message(WARNING "cppcheck not found!")
   endif(CPPCHECK_PATH)
 
   # ASan+LSan+UBsan / MSan / TSan
-  if(NOT ENABLE_TSAN AND NOT ENABLE_MSAN AND CMAKE_BUILD_TYPE STREQUAL "Debug")
-    # ASan is automatically enabled in Debug builds, unless TSan or MSan is enabled
+  if(NOT ENABLE_TSAN
+     AND NOT ENABLE_MSAN
+     AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+    # ASan is automatically enabled in Debug builds, unless TSan or MSan is
+    # enabled
     set(ENABLE_ASAN TRUE)
-  endif(NOT ENABLE_TSAN AND NOT ENABLE_MSAN AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+  endif(
+    NOT ENABLE_TSAN
+    AND NOT ENABLE_MSAN
+    AND CMAKE_BUILD_TYPE STREQUAL "Debug")
   if(ENABLE_TSAN)
     message("Enabling TSan")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=thread")
@@ -168,8 +202,10 @@ if(UNIX)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=memory")
   elseif(ENABLE_ASAN)
     message("Enabling ASan, LSan (GCC) and UBSan")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fsanitize=undefined")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address -fsanitize=undefined")
+    set(CMAKE_CXX_FLAGS
+        "${CMAKE_CXX_FLAGS} -fsanitize=address -fsanitize=undefined")
+    set(CMAKE_C_FLAGS
+        "${CMAKE_C_FLAGS} -fsanitize=address -fsanitize=undefined")
     if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=leak")
       set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=leak")
@@ -185,19 +221,32 @@ if(ENABLE_COVERAGE)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
 
-        add_custom_target(code_coverage
-          COMMAND lcov -c -d "${CMAKE_BINARY_DIR}" -o "${CMAKE_BINARY_DIR}/lcov.info" --exclude '/usr/include/*' --exclude '/usr/lib/*' --exclude '/usr/local/*'
-          COMMAND genhtml "${CMAKE_BINARY_DIR}/lcov.info" -o "${CMAKE_BINARY_DIR}/code_coverage_report" > "${CMAKE_BINARY_DIR}/genhtml.out" 2>&1
+        add_custom_target(
+          code_coverage
+          COMMAND
+            lcov -c -d "${CMAKE_BINARY_DIR}" -o "${CMAKE_BINARY_DIR}/lcov.info"
+            --exclude '/usr/include/*' --exclude '/usr/lib/*' --exclude
+            '/usr/local/*'
+          COMMAND
+            genhtml "${CMAKE_BINARY_DIR}/lcov.info" -o
+            "${CMAKE_BINARY_DIR}/code_coverage_report" >
+            "${CMAKE_BINARY_DIR}/genhtml.out" 2>&1
           COMMAND cat "${CMAKE_BINARY_DIR}/genhtml.out"
           COMMAND grep "lines.*100\.0\%" "${CMAKE_BINARY_DIR}/genhtml.out")
       else(CMAKE_C_COMPILER_ID STREQUAL "GNU")
-        message(WARNING "Can't enable code coverage checking as only GCC is supported")
+        message(
+          WARNING "Can't enable code coverage checking as only GCC is supported"
+        )
       endif(CMAKE_C_COMPILER_ID STREQUAL "GNU")
     else(CMAKE_BUILD_TYPE STREQUAL "Debug")
-      message(WARNING "Can't enable code coverage checking as only Debug builds are supported")
+      message(
+        WARNING
+          "Can't enable code coverage checking as only Debug builds are supported"
+      )
     endif(CMAKE_BUILD_TYPE STREQUAL "Debug")
   else(BUILD_TESTING)
-    message(WARNING "Can't enable code coverage checking as BUILD_TESTING is off")
+    message(
+      WARNING "Can't enable code coverage checking as BUILD_TESTING is off")
   endif(BUILD_TESTING)
 endif(ENABLE_COVERAGE)
 
@@ -207,7 +256,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 # Strict language standards
 set(C_STANDARD_REQUIRED TRUE)
 set(CXX_STANDARD_REQUIRED TRUE)
-if (NOT MSVC)
+if(NOT MSVC)
   add_compile_options(-Wall -Wextra -pedantic -Werror -Wno-unknown-pragmas)
 else()
   add_compile_options(/W4 /WX /wd4068 /wd4996)
@@ -217,23 +266,38 @@ endif()
 set(LINMATH_BRANCH "provizio")
 set(LINMATH_HEADER_DIR "${CMAKE_CURRENT_BINARY_DIR}/linmath")
 set(LINMATH_HEADER_NAME "linmath.h")
-set(LINMATH_DOWNLOAD_URL "https://raw.githubusercontent.com/provizio/linmath.h/${LINMATH_BRANCH}/${LINMATH_HEADER_NAME}")
-file(DOWNLOAD "${LINMATH_DOWNLOAD_URL}" "${LINMATH_HEADER_DIR}/${LINMATH_HEADER_NAME}" TLS_VERIFY ${TLS_VERIFY})
+set(LINMATH_DOWNLOAD_URL
+    "https://raw.githubusercontent.com/provizio/linmath.h/${LINMATH_BRANCH}/${LINMATH_HEADER_NAME}"
+)
+file(DOWNLOAD "${LINMATH_DOWNLOAD_URL}"
+     "${LINMATH_HEADER_DIR}/${LINMATH_HEADER_NAME}" TLS_VERIFY ${TLS_VERIFY})
 
 # Define the core library
-add_library(provizio_radar_api_core STATIC src/common.c src/socket.c src/radar_point_cloud.c src/radar_points_accumulation.c src/radar_points_accumulation_filters.c src/radar_points_accumulation_types.c src/util.c src/core.c)
+add_library(
+  provizio_radar_api_core STATIC
+  src/common.c
+  src/socket.c
+  src/radar_point_cloud.c
+  src/radar_points_accumulation.c
+  src/radar_points_accumulation_filters.c
+  src/radar_points_accumulation_types.c
+  src/util.c
+  src/core.c)
 target_include_directories(provizio_radar_api_core PUBLIC include)
-target_include_directories(provizio_radar_api_core SYSTEM PRIVATE "${LINMATH_HEADER_DIR}")
-set_property(TARGET provizio_radar_api_core PROPERTY C_STANDARD 99) # As defined by MISRA
+target_include_directories(provizio_radar_api_core SYSTEM
+                           PRIVATE "${LINMATH_HEADER_DIR}")
+set_property(TARGET provizio_radar_api_core PROPERTY C_STANDARD 99) # As defined
+                                                                    # by MISRA
 if(WIN32)
   target_link_libraries(provizio_radar_api_core ws2_32)
 endif(WIN32)
 
 # Installation config
-install(TARGETS provizio_radar_api_core
-        RUNTIME DESTINATION bin
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib)
+install(
+  TARGETS provizio_radar_api_core
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib)
 install(DIRECTORY include/provizio DESTINATION include)
 
 # Add tests, if enabled

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ There is a number of options to use it in your project. Some of the options:
 
     ```C
     // Somewhere in a header
-    
+
     void your_warning_handler(const char *warning);
     void your_error_handler(const char *error);
 
@@ -139,7 +139,7 @@ There is a number of options to use it in your project. Some of the options:
     * @note By default printing to stderr is used on warning.
     */
     provizio_set_on_warning(&your_warning_handler);
-    
+
     /**
     * @brief Specifies a custom function to be called on error
     *
@@ -179,7 +179,7 @@ There is a number of options to use it in your project. Some of the options:
     void* your_callback_data = <your optional callback data, may be NULL>;
 
     provizio_radar_point_cloud_api_context api_context;  // Large object, may cause stack overflow depending on your stack size
-    
+
     /**
     * @brief Initializes a provizio_radar_point_cloud_api_context object to handle a single radar
     *
@@ -208,7 +208,7 @@ There is a number of options to use it in your project. Some of the options:
 
     provizio_radar_point_cloud_api_context *api_contexts =
         (provizio_radar_point_cloud_api_context *)malloc(sizeof(provizio_radar_point_cloud_api_context) * num_contexts);
-    
+
     /**
     * @brief Initializes multiple provizio_radar_point_cloud_api_context objects to handle packets from multiple radars
     *
@@ -920,7 +920,7 @@ The Provizio radars UDP protocol:
 
 - Binary packets up to 1472 bytes long​
 - Can tolerate lost packets​
-- Point Clouds: up to 65535 points per point cloud, up to 72 points per UDP packet​
+- Point Clouds: up to 65535 points per point cloud, up to 60 points per UDP packet​
 - Supports single or multiple radars, on the same or different ports​
 - Permits identifying radars by position ids to allow for replacing radars easily​
 
@@ -932,24 +932,25 @@ Each packet has a size of 1472 bytes or less, depending on a number of points it
 
 Each packet has the following structure (all fields use network bytes order when applicable, no padding):
 
-| Field                          | Size (bytes)                         | Data Type | Description                                                                                                                     |
-| ------------------------------ | ------------------------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| packet_type                    | 2                                    | uint16_t  | Always = 1, can't change even on protocol updates                                                                               |
-| protocol_version               | 2                                    | uint16_t  | Currently = 1, to be incremented on any protocol changes (used for backward compatibility)                                      |
-| frame_index                    | 4                                    | uint32_t  | 0-based frame index (resets back to 0 if ever exceeds 4294967295)                                                               |
-| timestamp                      | 8                                    | uint64_t  | Time of the frame capture measured in absolute number of nanoseconds since the start of the GPS Epoch (midnight on Jan 6, 1980) |
-| radar_position_id              | 2                                    | uint16_t  | Either one of provizio_radar_position enum values or a custom position id                                                       |
-| total_points_in_frame          | 2                                    | uint16_t  | Total number of points in the frame #frame_index, never exceeds 65535                                                           |
-| num_points_in_packet           | 2                                    | uint16_t  | Number of points in the current packet, never exceeds (1472 - 24) / 20                                                          |
-| radar_mode                     | 2                                    | uint16_t  | Radar mode, one of provizio_radar_mode enum values                                                                              |
-| point_0: x_meters              | 4                                    | float     | Radar-relative X (forward) position of the point in meters                                                                      |
-| point_0: y_meters              | 4                                    | float     | Radar-relative Y (left) position of the point in meters                                                                         |
-| point_0: z_meters              | 4                                    | float     | Radar-relative Z (up) position of the point in meters                                                                           |
-| point_0: velocity_m_s          | 4                                    | float     | Radar-relative velocity of the point in meters per second                                                                       |
-| point_0: signal_to_noise_ratio | 4                                    | float     | Signal-to-noise ratio (unitless)                                                                                                |
-| point_1: ...                   |                                      |           |                                                                                                                                 |
-| ...                            |                                      |           |                                                                                                                                 |
-| **Total**                      | **24 + (20 * num_points_in_packet)** |           | Never exceeds 1472 bytes                                                                                                        |
+| Field                                                 | Size (bytes)                         | Data Type | Description                                                                                                                     |
+| ----------------------------------------------------- | ------------------------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| packet_type                                           | 2                                    | uint16_t  | Always = 1, can't change even on protocol updates                                                                               |
+| protocol_version                                      | 2                                    | uint16_t  | Currently = 1, to be incremented on any protocol changes (used for backward compatibility)                                      |
+| frame_index                                           | 4                                    | uint32_t  | 0-based frame index (resets back to 0 if ever exceeds 4294967295)                                                               |
+| timestamp                                             | 8                                    | uint64_t  | Time of the frame capture measured in absolute number of nanoseconds since the start of the GPS Epoch (midnight on Jan 6, 1980) |
+| radar_position_id                                     | 2                                    | uint16_t  | Either one of provizio_radar_position enum values or a custom position id                                                       |
+| total_points_in_frame                                 | 2                                    | uint16_t  | Total number of points in the frame #frame_index, never exceeds 65535                                                           |
+| num_points_in_packet                                  | 2                                    | uint16_t  | Number of points in the current packet, never exceeds (1472 - 24) / 24                                                          |
+| radar_mode                                            | 2                                    | uint16_t  | Radar mode, one of provizio_radar_mode enum values                                                                              |
+| point_0: x_meters                                     | 4                                    | float     | Radar-relative X (forward) position of the point in meters                                                                      |
+| point_0: y_meters                                     | 4                                    | float     | Radar-relative Y (left) position of the point in meters                                                                         |
+| point_0: z_meters                                     | 4                                    | float     | Radar-relative Z (up) position of the point in meters                                                                           |
+| point_0: radar_relative_radial velocity_m_s           | 4                                    | float     | Radar-relative velocity of the point in meters per second                                                                       |
+| point_0: signal_to_noise_ratio                        | 4                                    | float     | Signal-to-noise ratio (unitless)                                                                                                |
+| point_0: ground_relative_radial velocity_m_s          | 4                                    | float     | Radar-relative velocity of the point in meters per second                                                                       |
+| point_1: ...                                          |                                      |           |                                                                                                                                 |
+| ...                                                   |                                      |           |                                                                                                                                 |
+| **Total**                                             | **24 + (24 * num_points_in_packet)** |           | Never exceeds 1472 bytes                                                                                                        |
 
 ### Radar Modes
 

--- a/include/provizio/radar_api/radar_point_cloud.h
+++ b/include/provizio/radar_api/radar_point_cloud.h
@@ -38,24 +38,24 @@
  */
 typedef struct
 {
-    float x_meters;     // Forward, radar relative
-    float y_meters;     // Left, radar relative
-    float z_meters;     // Up, radar relative
-    float radar_relative_radial_velocity_m_s;   // Forward, radar relative
+    float x_meters;                           // Forward, radar relative
+    float y_meters;                           // Left, radar relative
+    float z_meters;                           // Up, radar relative
+    float radar_relative_radial_velocity_m_s; // Forward, radar relative
     float signal_to_noise_ratio;
-    float ground_relative_radial_velocity_m_s;  // Ground relative projection to the radar forward axis (NaN if unavailable)
+    float ground_relative_radial_velocity_m_s; // Ground relative projection to the radar forward axis (NaN if
+                                               // unavailable)
 } provizio_radar_point;
 
 // Backwards-compatibility (deprecated)
 typedef struct
 {
-    float x_meters;     // Forward, radar relative
-    float y_meters;     // Left, radar relative
-    float z_meters;     // Up, radar relative
-    float radar_relative_radial_velocity_m_s;   // Forward, radar relative
+    float x_meters;                           // Forward, radar relative
+    float y_meters;                           // Left, radar relative
+    float z_meters;                           // Up, radar relative
+    float radar_relative_radial_velocity_m_s; // Forward, radar relative
     float signal_to_noise_ratio;
 } provizio_radar_point_v1_protocol;
-
 
 /**
  * @brief Header placed in the beginning of each radar point cloud packet.

--- a/include/provizio/radar_api/radar_point_cloud.h
+++ b/include/provizio/radar_api/radar_point_cloud.h
@@ -21,7 +21,7 @@
 #include "provizio/socket.h"
 
 // To be incremented on any breaking protocol changes (used for backward compatibility)
-#define PROVIZIO__RADAR_API_POINT_CLOUD_PROTOCOL_VERSION ((uint16_t)1)
+#define PROVIZIO__RADAR_API_POINT_CLOUD_PROTOCOL_VERSION ((uint16_t)2)
 
 // Radar point cloud structures of the binary UDP protocol are defined here, see README.md for more details
 
@@ -41,9 +41,21 @@ typedef struct
     float x_meters;     // Forward, radar relative
     float y_meters;     // Left, radar relative
     float z_meters;     // Up, radar relative
-    float velocity_m_s; // Forward, radar relative
+    float radar_relative_radial_velocity_m_s;   // Forward, radar relative
     float signal_to_noise_ratio;
+    float ground_relative_radial_velocity_m_s;  // Ground relative projection to the radar forward axis (NaN if unavailable)
 } provizio_radar_point;
+
+// Backwards-compatibility (deprecated)
+typedef struct
+{
+    float x_meters;     // Forward, radar relative
+    float y_meters;     // Left, radar relative
+    float z_meters;     // Up, radar relative
+    float radar_relative_radial_velocity_m_s;   // Forward, radar relative
+    float signal_to_noise_ratio;
+} provizio_radar_point_v1_protocol;
+
 
 /**
  * @brief Header placed in the beginning of each radar point cloud packet.

--- a/include/provizio/radar_api/radar_point_cloud.h
+++ b/include/provizio/radar_api/radar_point_cloud.h
@@ -283,6 +283,16 @@ static_assert(sizeof(provizio_radar_point_cloud_packet) ==
                   sizeof(provizio_radar_point_cloud_packet_header) +
                       sizeof(provizio_radar_point) * PROVIZIO__MAX_RADAR_POINTS_PER_UDP_PACKET,
               "Unexpected size of provizio_radar_point_cloud_packet");
+static_assert(offsetof(provizio_radar_point, x_meters) == 0, "Unexpected position of x_meters in provizio_radar_point");
+static_assert(offsetof(provizio_radar_point, y_meters) == 4, "Unexpected position of y_meters in provizio_radar_point");
+static_assert(offsetof(provizio_radar_point, z_meters) == 8, "Unexpected position of z_meters in provizio_radar_point");
+static_assert(offsetof(provizio_radar_point, radar_relative_radial_velocity_m_s) == 12,
+              "Unexpected position of radar_relative_radial_velocity_m_s in provizio_radar_point");
+static_assert(offsetof(provizio_radar_point, signal_to_noise_ratio) == 16,
+              "Unexpected position of signal_to_noise_ratio in provizio_radar_point");
+static_assert(offsetof(provizio_radar_point, ground_relative_radial_velocity_m_s) == 20,
+              "Unexpected position of ground_relative_radial_velocity_m_s in provizio_radar_point");
+static_assert(sizeof(provizio_radar_point) == 24, "Unexpected size of provizio_radar_point");
 #endif // defined(__cplusplus) && __cplusplus >= 201103L
 
 #endif // PROVIZIO_RADAR_API_RADAR_POINT_CLOUD

--- a/include/provizio/radar_api/radar_point_cloud.h
+++ b/include/provizio/radar_api/radar_point_cloud.h
@@ -47,16 +47,6 @@ typedef struct
                                                // unavailable)
 } provizio_radar_point;
 
-// Backwards-compatibility (deprecated)
-typedef struct
-{
-    float x_meters;                           // Forward, radar relative
-    float y_meters;                           // Left, radar relative
-    float z_meters;                           // Up, radar relative
-    float radar_relative_radial_velocity_m_s; // Forward, radar relative
-    float signal_to_noise_ratio;
-} provizio_radar_point_v1_protocol;
-
 /**
  * @brief Header placed in the beginning of each radar point cloud packet.
  *

--- a/src/radar_point_cloud.c
+++ b/src/radar_point_cloud.c
@@ -22,14 +22,16 @@
 #include "provizio/util.h"
 
 // deprecated structure used for backwards compatibility
-struct provizio_radar_point_protocol_v1
+#pragma pack(push, 1)
+typedef struct provizio_radar_point_protocol_v1
 {
     float x_meters;
     float y_meters;
     float z_meters;
     float radar_relative_radial_velocity_m_s;
     float signal_to_noise_ratio;
-};
+} provizio_radar_point_protocol_v1;
+#pragma pack(pop)
 
 static int provizio_network_floats_reversed(void)
 {
@@ -170,7 +172,7 @@ size_t provizio_radar_point_cloud_packet_size(const provizio_radar_point_cloud_p
     const uint16_t protocol_version = provizio_get_protocol_field_uint16_t(&header->protocol_header.protocol_version);
 
     if ((protocol_version == 1) && num_points > (PROVIZIO__MTU - sizeof(provizio_radar_point_cloud_packet_header)) /
-                                                    sizeof(struct provizio_radar_point_protocol_v1))
+                                                    sizeof(provizio_radar_point_protocol_v1))
     {
         provizio_warning("provizio_radar_point_cloud_packet_size: num_points_in_packet exceeds "
                          "maximum allowed points for version 1 of the protocol!");
@@ -327,8 +329,7 @@ int32_t provizio_handle_radar_point_cloud_packet_checked(provizio_radar_point_cl
             }
             else if (protocol_version == 1)
             {
-                in_point =
-                    (provizio_radar_point *)&(((struct provizio_radar_point_protocol_v1 *)packet->radar_points)[i]);
+                in_point = (provizio_radar_point *)&(((provizio_radar_point_protocol_v1 *)packet->radar_points)[i]);
             }
             else
             {

--- a/src/radar_point_cloud.c
+++ b/src/radar_point_cloud.c
@@ -297,7 +297,7 @@ int32_t provizio_handle_radar_point_cloud_packet_checked(provizio_radar_point_cl
         for (uint16_t i = 0; i < num_points_in_packet; ++i)
         {
             provizio_radar_point *out_point = &cloud->radar_points[cloud->num_points_received + i];
-            provizio_radar_point *in_point;
+            provizio_radar_point *in_point = NULL;
 
             if(protocol_version >= 2)
             {
@@ -306,6 +306,11 @@ int32_t provizio_handle_radar_point_cloud_packet_checked(provizio_radar_point_cl
             else if(protocol_version == 1)
             {
                 in_point = (provizio_radar_point *) &(((provizio_radar_point_v1_protocol *) packet->radar_points)[i]);
+            }
+            else
+            {
+                provizio_error("provizio_handle_radar_point_cloud_packet_checked: invalid protocol version");
+                return PROVIZIO_E_PROTOCOL;
             }
 
             out_point->x_meters = provizio_get_protocol_field_float(&in_point->x_meters);

--- a/src/radar_point_cloud.c
+++ b/src/radar_point_cloud.c
@@ -16,6 +16,7 @@
 
 #include <assert.h>
 #include <string.h>
+#include <math.h>
 
 #include "provizio/radar_api/errno.h"
 #include "provizio/util.h"
@@ -279,28 +280,48 @@ int32_t provizio_handle_radar_point_cloud_packet_checked(provizio_radar_point_cl
         return PROVIZIO_E_PROTOCOL;
     }
 
+    const uint16_t protocol_version = provizio_get_protocol_field_uint16_t(&packet->header.protocol_header.protocol_version);
+
     // Append new points to the point cloud being received
-    if (!provizio_network_floats_reversed())
+    if (!provizio_network_floats_reversed() && (protocol_version >= 2))
     {
         // Optimized version: host machine uses network byte order for floats, no need to convert them
         // LCOV_EXCL_START: host CPU arch dependent
         memcpy(&cloud->radar_points[cloud->num_points_received], &packet->radar_points,
-               sizeof(provizio_radar_point) * num_points_in_packet);
+            sizeof(provizio_radar_point) * num_points_in_packet);
         // LCOV_EXCL_STOP
     }
     else
     {
-        // Every value has to be converted to the host byte order
         // LCOV_EXCL_START: host CPU arch dependent
         for (uint16_t i = 0; i < num_points_in_packet; ++i)
         {
             provizio_radar_point *out_point = &cloud->radar_points[cloud->num_points_received + i];
-            provizio_radar_point *in_point = &packet->radar_points[i];
+            provizio_radar_point *in_point;
+
+            if(protocol_version >= 2)
+            {
+                in_point = &packet->radar_points[i];
+            }
+            else if(protocol_version == 1)
+            {
+                in_point = (provizio_radar_point *) &(((provizio_radar_point_v1_protocol *) packet->radar_points)[i]);
+            }
+
             out_point->x_meters = provizio_get_protocol_field_float(&in_point->x_meters);
             out_point->y_meters = provizio_get_protocol_field_float(&in_point->y_meters);
             out_point->z_meters = provizio_get_protocol_field_float(&in_point->z_meters);
-            out_point->velocity_m_s = provizio_get_protocol_field_float(&in_point->velocity_m_s);
+            out_point->radar_relative_radial_velocity_m_s = provizio_get_protocol_field_float(&in_point->radar_relative_radial_velocity_m_s);
             out_point->signal_to_noise_ratio = provizio_get_protocol_field_float(&in_point->signal_to_noise_ratio);
+
+            if(protocol_version >= 2)
+            {
+                out_point->ground_relative_radial_velocity_m_s = provizio_get_protocol_field_float(&in_point->ground_relative_radial_velocity_m_s);
+            }
+            else
+            {
+                out_point->ground_relative_radial_velocity_m_s = nanf("");
+            }
         }
         // LCOV_EXCL_STOP
     }

--- a/src/radar_point_cloud.c
+++ b/src/radar_point_cloud.c
@@ -15,8 +15,8 @@
 #include "provizio/radar_api/radar_point_cloud.h"
 
 #include <assert.h>
-#include <string.h>
 #include <math.h>
+#include <string.h>
 
 #include "provizio/radar_api/errno.h"
 #include "provizio/util.h"
@@ -280,7 +280,8 @@ int32_t provizio_handle_radar_point_cloud_packet_checked(provizio_radar_point_cl
         return PROVIZIO_E_PROTOCOL;
     }
 
-    const uint16_t protocol_version = provizio_get_protocol_field_uint16_t(&packet->header.protocol_header.protocol_version);
+    const uint16_t protocol_version =
+        provizio_get_protocol_field_uint16_t(&packet->header.protocol_header.protocol_version);
 
     // Append new points to the point cloud being received
     if (!provizio_network_floats_reversed() && (protocol_version >= 2))
@@ -288,7 +289,7 @@ int32_t provizio_handle_radar_point_cloud_packet_checked(provizio_radar_point_cl
         // Optimized version: host machine uses network byte order for floats, no need to convert them
         // LCOV_EXCL_START: host CPU arch dependent
         memcpy(&cloud->radar_points[cloud->num_points_received], &packet->radar_points,
-            sizeof(provizio_radar_point) * num_points_in_packet);
+               sizeof(provizio_radar_point) * num_points_in_packet);
         // LCOV_EXCL_STOP
     }
     else
@@ -299,13 +300,13 @@ int32_t provizio_handle_radar_point_cloud_packet_checked(provizio_radar_point_cl
             provizio_radar_point *out_point = &cloud->radar_points[cloud->num_points_received + i];
             provizio_radar_point *in_point = NULL;
 
-            if(protocol_version >= 2)
+            if (protocol_version >= 2)
             {
                 in_point = &packet->radar_points[i];
             }
-            else if(protocol_version == 1)
+            else if (protocol_version == 1)
             {
-                in_point = (provizio_radar_point *) &(((provizio_radar_point_v1_protocol *) packet->radar_points)[i]);
+                in_point = (provizio_radar_point *)&(((provizio_radar_point_v1_protocol *)packet->radar_points)[i]);
             }
             else
             {
@@ -316,12 +317,14 @@ int32_t provizio_handle_radar_point_cloud_packet_checked(provizio_radar_point_cl
             out_point->x_meters = provizio_get_protocol_field_float(&in_point->x_meters);
             out_point->y_meters = provizio_get_protocol_field_float(&in_point->y_meters);
             out_point->z_meters = provizio_get_protocol_field_float(&in_point->z_meters);
-            out_point->radar_relative_radial_velocity_m_s = provizio_get_protocol_field_float(&in_point->radar_relative_radial_velocity_m_s);
+            out_point->radar_relative_radial_velocity_m_s =
+                provizio_get_protocol_field_float(&in_point->radar_relative_radial_velocity_m_s);
             out_point->signal_to_noise_ratio = provizio_get_protocol_field_float(&in_point->signal_to_noise_ratio);
 
-            if(protocol_version >= 2)
+            if (protocol_version >= 2)
             {
-                out_point->ground_relative_radial_velocity_m_s = provizio_get_protocol_field_float(&in_point->ground_relative_radial_velocity_m_s);
+                out_point->ground_relative_radial_velocity_m_s =
+                    provizio_get_protocol_field_float(&in_point->ground_relative_radial_velocity_m_s);
             }
             else
             {

--- a/src/radar_points_accumulation.c
+++ b/src/radar_points_accumulation.c
@@ -65,7 +65,8 @@ static void provizio_transform_radar_point(const provizio_radar_point *point, co
     out_transformed_point->x_meters = out_point[0];
     out_transformed_point->y_meters = out_point[1];
     out_transformed_point->z_meters = out_point[2];
-    out_transformed_point->radar_relative_radial_velocity_m_s = point->radar_relative_radial_velocity_m_s;
+    out_transformed_point->radar_relative_radial_velocity_m_s =
+        point->radar_relative_radial_velocity_m_s; // TODO(APT-746): Consider updating velocity
     out_transformed_point->ground_relative_radial_velocity_m_s = point->ground_relative_radial_velocity_m_s;
     out_transformed_point->signal_to_noise_ratio = point->signal_to_noise_ratio;
 }

--- a/src/radar_points_accumulation.c
+++ b/src/radar_points_accumulation.c
@@ -65,7 +65,8 @@ static void provizio_transform_radar_point(const provizio_radar_point *point, co
     out_transformed_point->x_meters = out_point[0];
     out_transformed_point->y_meters = out_point[1];
     out_transformed_point->z_meters = out_point[2];
-    out_transformed_point->velocity_m_s = point->velocity_m_s; // TODO(APT-746): Consider updating velocity
+    out_transformed_point->radar_relative_radial_velocity_m_s = point->radar_relative_radial_velocity_m_s;
+    out_transformed_point->ground_relative_radial_velocity_m_s = point->ground_relative_radial_velocity_m_s;
     out_transformed_point->signal_to_noise_ratio = point->signal_to_noise_ratio;
 }
 

--- a/src/radar_points_accumulation_filters.c
+++ b/src/radar_points_accumulation_filters.c
@@ -243,7 +243,8 @@ void provizio_radar_points_accumulation_filter_static(
     uint16_t num_filtered_points = 0;
     for (const provizio_radar_point *point = in_points, *end = in_points + num_in_points; point != end; ++point)
     {
-        // TODO(iivanov): uncomment this fix and update the unit tests
+        // TODO(APT-1667): dynamic adjustment of ground-relative velocity accounting for angular differences of
+        // detections
         // if (fabsf(point->radar_relative_radial_velocity_m_s + radars_forward_velocity_m_s *
         // cosf(atan2f(point->y_meters, point->x_meters) * -1)) < dynamic_velocity_threashold_m_s)
         if (fabsf(point->radar_relative_radial_velocity_m_s + radars_forward_velocity_m_s) <

--- a/src/radar_points_accumulation_filters.c
+++ b/src/radar_points_accumulation_filters.c
@@ -44,7 +44,7 @@ static float provizio_estimate_radars_forward_velocity_using_velocities_histogra
 
     for (uint16_t i = 0; i < num_in_points; ++i)
     {
-        const float velocity = in_points[i].velocity_m_s;
+        const float velocity = in_points[i].radar_relative_radial_velocity_m_s;
         if (velocity < min_velocity)
         {
             min_velocity = velocity;
@@ -76,7 +76,7 @@ static float provizio_estimate_radars_forward_velocity_using_velocities_histogra
     uint16_t largest_bin_value = 0;
     for (uint16_t i = 0; i < num_in_points; ++i)
     {
-        const float velocity = in_points[i].velocity_m_s;
+        const float velocity = in_points[i].radar_relative_radial_velocity_m_s;
         const size_t bin =
             (size_t)lroundf((velocity - min_velocity) / bin_size) * (histogram_bins - 1) / histogram_bins;
         assert(bin < histogram_bins);
@@ -243,7 +243,9 @@ void provizio_radar_points_accumulation_filter_static(
     uint16_t num_filtered_points = 0;
     for (const provizio_radar_point *point = in_points, *end = in_points + num_in_points; point != end; ++point)
     {
-        if (fabsf(point->velocity_m_s + radars_forward_velocity_m_s) < dynamic_velocity_threashold_m_s)
+        // TODO: uncomment this fix and update the unit tests
+        //if (fabsf(point->radar_relative_radial_velocity_m_s + radars_forward_velocity_m_s * cosf(atan2f(point->y_meters, point->x_meters) * -1)) < dynamic_velocity_threashold_m_s)
+        if (fabsf(point->radar_relative_radial_velocity_m_s + radars_forward_velocity_m_s) < dynamic_velocity_threashold_m_s)
         {
             // Static point, let's accumulate it
             out_points[num_filtered_points++] = *point;

--- a/src/radar_points_accumulation_filters.c
+++ b/src/radar_points_accumulation_filters.c
@@ -244,8 +244,10 @@ void provizio_radar_points_accumulation_filter_static(
     for (const provizio_radar_point *point = in_points, *end = in_points + num_in_points; point != end; ++point)
     {
         // TODO: uncomment this fix and update the unit tests
-        //if (fabsf(point->radar_relative_radial_velocity_m_s + radars_forward_velocity_m_s * cosf(atan2f(point->y_meters, point->x_meters) * -1)) < dynamic_velocity_threashold_m_s)
-        if (fabsf(point->radar_relative_radial_velocity_m_s + radars_forward_velocity_m_s) < dynamic_velocity_threashold_m_s)
+        // if (fabsf(point->radar_relative_radial_velocity_m_s + radars_forward_velocity_m_s *
+        // cosf(atan2f(point->y_meters, point->x_meters) * -1)) < dynamic_velocity_threashold_m_s)
+        if (fabsf(point->radar_relative_radial_velocity_m_s + radars_forward_velocity_m_s) <
+            dynamic_velocity_threashold_m_s)
         {
             // Static point, let's accumulate it
             out_points[num_filtered_points++] = *point;

--- a/src/radar_points_accumulation_filters.c
+++ b/src/radar_points_accumulation_filters.c
@@ -243,7 +243,7 @@ void provizio_radar_points_accumulation_filter_static(
     uint16_t num_filtered_points = 0;
     for (const provizio_radar_point *point = in_points, *end = in_points + num_in_points; point != end; ++point)
     {
-        // TODO: uncomment this fix and update the unit tests
+        // TODO(iivanov): uncomment this fix and update the unit tests
         // if (fabsf(point->radar_relative_radial_velocity_m_s + radars_forward_velocity_m_s *
         // cosf(atan2f(point->y_meters, point->x_meters) * -1)) < dynamic_velocity_threashold_m_s)
         if (fabsf(point->radar_relative_radial_velocity_m_s + radars_forward_velocity_m_s) <

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,16 +1,16 @@
 # Copyright 2022 Provizio Ltd.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
 
 cmake_minimum_required(VERSION 3.1.0)
 
@@ -24,21 +24,25 @@ set(UNITY_PREFIX "${CMAKE_CURRENT_BINARY_DIR}")
 set(UNITY_GITHUB_PROJECT "provizio/Unity")
 set(UNITY_GITHUB_BRANCH "provizio")
 set(UNITY_INSTALL_DIR "${UNITY_BINARY_DIR}/install")
-ExternalProject_Add(unity
-    GIT_REPOSITORY "https://github.com/${UNITY_GITHUB_PROJECT}.git"
-    GIT_TAG "${UNITY_GITHUB_BRANCH}"
-    PREFIX "${UNITY_PREFIX}"
-    SOURCE_DIR "${UNITY_SOURCE_DIR}"
-    BINARY_DIR "${UNITY_BINARY_DIR}"
-    CMAKE_ARGS "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}" "-DCMAKE_INSTALL_PREFIX=${UNITY_INSTALL_DIR}" "-DUNITY_CONFIG_DIR=${CMAKE_CURRENT_SOURCE_DIR}/include"
-    INSTALL_DIR "${UNITY_INSTALL_DIR}"
-)
-include_directories("${UNITY_INSTALL_DIR}/include" "${CMAKE_CURRENT_SOURCE_DIR}/include")
+ExternalProject_Add(
+  unity
+  GIT_REPOSITORY "https://github.com/${UNITY_GITHUB_PROJECT}.git"
+  GIT_TAG "${UNITY_GITHUB_BRANCH}"
+  PREFIX "${UNITY_PREFIX}"
+  SOURCE_DIR "${UNITY_SOURCE_DIR}"
+  BINARY_DIR "${UNITY_BINARY_DIR}"
+  CMAKE_ARGS "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
+             "-DCMAKE_INSTALL_PREFIX=${UNITY_INSTALL_DIR}"
+             "-DUNITY_CONFIG_DIR=${CMAKE_CURRENT_SOURCE_DIR}/include"
+  INSTALL_DIR "${UNITY_INSTALL_DIR}")
+include_directories("${UNITY_INSTALL_DIR}/include"
+                    "${CMAKE_CURRENT_SOURCE_DIR}/include")
 link_directories("${UNITY_INSTALL_DIR}/lib")
 add_definitions(-DUNITY_INCLUDE_CONFIG_H)
 
 if(MSVC)
-  # Make stack 8Mb large (as default MSVCs 1Mb is not enough for storing api contexts)
+  # Make stack 8Mb large (as default MSVCs 1Mb is not enough for storing api
+  # contexts)
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /STACK:8388608")
 endif(MSVC)
 

--- a/test/c_99/CMakeLists.txt
+++ b/test/c_99/CMakeLists.txt
@@ -1,43 +1,55 @@
 # Copyright 2022 Provizio Ltd.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
 
 cmake_minimum_required(VERSION 3.1.0)
 
 if(WIN32)
   # Resolve pthread-win32 (https://github.com/provizio/pthread-win32)
-  set(PTHREAD_WIN32_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/pthread_win32_build")
+  set(PTHREAD_WIN32_BINARY_DIR
+      "${CMAKE_CURRENT_BINARY_DIR}/pthread_win32_build")
   set(PTHREAD_WIN32_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/pthread_win32")
   set(PTHREAD_WIN32_PREFIX "${CMAKE_CURRENT_BINARY_DIR}")
   set(PTHREAD_WIN32_GITHUB_PROJECT "provizio/pthread-win32")
   set(PTHREAD_WIN32_GITHUB_BRANCH "v3.0.3.1")
   set(PTHREAD_WIN32_INSTALL_DIR "${PTHREAD_WIN32_BINARY_DIR}/install")
-  ExternalProject_Add(pthread_win32
-      GIT_REPOSITORY "https://github.com/${PTHREAD_WIN32_GITHUB_PROJECT}.git"
-      GIT_TAG "${PTHREAD_WIN32_GITHUB_BRANCH}"
-      PREFIX "${PTHREAD_WIN32_PREFIX}"
-      SOURCE_DIR "${PTHREAD_WIN32_SOURCE_DIR}"
-      BINARY_DIR "${PTHREAD_WIN32_BINARY_DIR}"
-      CMAKE_ARGS "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}" "-DCMAKE_INSTALL_PREFIX=${PTHREAD_WIN32_INSTALL_DIR}"
-      INSTALL_DIR "${PTHREAD_WIN32_INSTALL_DIR}"
-  )
-  include_directories("${PTHREAD_WIN32_INSTALL_DIR}/ARM/${CMAKE_BUILD_TYPE}/include" "${PTHREAD_WIN32_INSTALL_DIR}/ARM64/${CMAKE_BUILD_TYPE}/include" "${PTHREAD_WIN32_INSTALL_DIR}/x86_64/${CMAKE_BUILD_TYPE}/include" "${PTHREAD_WIN32_INSTALL_DIR}/x86/${CMAKE_BUILD_TYPE}/include" "${PTHREAD_WIN32_INSTALL_DIR}/x64/${CMAKE_BUILD_TYPE}/include")
-  link_directories("${PTHREAD_WIN32_INSTALL_DIR}/ARM/${CMAKE_BUILD_TYPE}/lib" "${PTHREAD_WIN32_INSTALL_DIR}/ARM64/${CMAKE_BUILD_TYPE}/lib" "${PTHREAD_WIN32_INSTALL_DIR}/x86_64/${CMAKE_BUILD_TYPE}/lib" "${PTHREAD_WIN32_INSTALL_DIR}/x86/${CMAKE_BUILD_TYPE}/lib" "${PTHREAD_WIN32_INSTALL_DIR}/x64/${CMAKE_BUILD_TYPE}/lib")
+  ExternalProject_Add(
+    pthread_win32
+    GIT_REPOSITORY "https://github.com/${PTHREAD_WIN32_GITHUB_PROJECT}.git"
+    GIT_TAG "${PTHREAD_WIN32_GITHUB_BRANCH}"
+    PREFIX "${PTHREAD_WIN32_PREFIX}"
+    SOURCE_DIR "${PTHREAD_WIN32_SOURCE_DIR}"
+    BINARY_DIR "${PTHREAD_WIN32_BINARY_DIR}"
+    CMAKE_ARGS "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
+               "-DCMAKE_INSTALL_PREFIX=${PTHREAD_WIN32_INSTALL_DIR}"
+    INSTALL_DIR "${PTHREAD_WIN32_INSTALL_DIR}")
+  include_directories(
+    "${PTHREAD_WIN32_INSTALL_DIR}/ARM/${CMAKE_BUILD_TYPE}/include"
+    "${PTHREAD_WIN32_INSTALL_DIR}/ARM64/${CMAKE_BUILD_TYPE}/include"
+    "${PTHREAD_WIN32_INSTALL_DIR}/x86_64/${CMAKE_BUILD_TYPE}/include"
+    "${PTHREAD_WIN32_INSTALL_DIR}/x86/${CMAKE_BUILD_TYPE}/include"
+    "${PTHREAD_WIN32_INSTALL_DIR}/x64/${CMAKE_BUILD_TYPE}/include")
+  link_directories(
+    "${PTHREAD_WIN32_INSTALL_DIR}/ARM/${CMAKE_BUILD_TYPE}/lib"
+    "${PTHREAD_WIN32_INSTALL_DIR}/ARM64/${CMAKE_BUILD_TYPE}/lib"
+    "${PTHREAD_WIN32_INSTALL_DIR}/x86_64/${CMAKE_BUILD_TYPE}/lib"
+    "${PTHREAD_WIN32_INSTALL_DIR}/x86/${CMAKE_BUILD_TYPE}/lib"
+    "${PTHREAD_WIN32_INSTALL_DIR}/x64/${CMAKE_BUILD_TYPE}/lib")
   set(PTHREAD_LIB libpthreadVC3)
   if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-  set(PTHREAD_LIB "${PTHREAD_LIB}d")
+    set(PTHREAD_LIB "${PTHREAD_LIB}d")
   endif(CMAKE_BUILD_TYPE STREQUAL "Debug")
-  
+
   set(MATH_LIB "")
 else(WIN32)
   find_package(Threads)
@@ -45,10 +57,23 @@ else(WIN32)
   set(MATH_LIB m)
 endif(WIN32)
 
-add_executable(provizio_radar_api_core_test_c_99 src/test_main.c src/test_common.c src/test_util.c src/test_radar_point_cloud.c src/test_radar_points_accumulation_types.c src/test_radar_points_accumulation_filters.c src/test_radar_points_accumulation.c src/test_core.c)
-target_include_directories(provizio_radar_api_core_test_c_99 PRIVATE ${CMAKE_BINARY_DIR}/linmath)
-target_link_libraries(provizio_radar_api_core_test_c_99 provizio_radar_api_core unity_testing ${MATH_LIB} ${PTHREAD_LIB})
-set_property(TARGET provizio_radar_api_core_test_c_99 PROPERTY C_STANDARD 99) # As defined by MISRA
+add_executable(
+  provizio_radar_api_core_test_c_99
+  src/test_main.c
+  src/test_common.c
+  src/test_util.c
+  src/test_radar_point_cloud.c
+  src/test_radar_points_accumulation_types.c
+  src/test_radar_points_accumulation_filters.c
+  src/test_radar_points_accumulation.c
+  src/test_core.c)
+target_include_directories(provizio_radar_api_core_test_c_99
+                           PRIVATE ${CMAKE_BINARY_DIR}/linmath)
+target_link_libraries(provizio_radar_api_core_test_c_99 provizio_radar_api_core
+                      unity_testing ${MATH_LIB} ${PTHREAD_LIB})
+set_property(TARGET provizio_radar_api_core_test_c_99 PROPERTY C_STANDARD 99
+)# As defined by MISRA
 add_dependencies(provizio_radar_api_core_test_c_99 unity)
 
-add_test(NAME provizio_radar_api_core_test_c_99 COMMAND provizio_radar_api_core_test_c_99)
+add_test(NAME provizio_radar_api_core_test_c_99
+         COMMAND provizio_radar_api_core_test_c_99)

--- a/test/c_99/src/test_core.c
+++ b/test/c_99/src/test_core.c
@@ -409,9 +409,8 @@ static void test_receives_single_radar_point_cloud_from_single_radar(void)
                             callback_data->last_point_clouds[0].radar_points[num_points - 1].y_meters);
     TEST_ASSERT_EQUAL_FLOAT(22.4543F, // NOLINT
                             callback_data->last_point_clouds[0].radar_points[num_points - 1].z_meters);
-    TEST_ASSERT_EQUAL_FLOAT(
-        -1.95574F, // NOLINT
-        callback_data->last_point_clouds[0].radar_points[num_points - 1].radar_relative_radial_velocity_m_s);
+    TEST_ASSERT_EQUAL_FLOAT( // NOLINT
+        -1.95574F, callback_data->last_point_clouds[0].radar_points[num_points - 1].radar_relative_radial_velocity_m_s);
     TEST_ASSERT_EQUAL_FLOAT(42.63091F, // NOLINT
                             callback_data->last_point_clouds[0].radar_points[num_points - 1].signal_to_noise_ratio);
 
@@ -422,9 +421,8 @@ static void test_receives_single_radar_point_cloud_from_single_radar(void)
                             callback_data->last_point_clouds[0].radar_points[num_points].y_meters);
     TEST_ASSERT_EQUAL_FLOAT(0.0F, // NOLINT
                             callback_data->last_point_clouds[0].radar_points[num_points].z_meters);
-    TEST_ASSERT_EQUAL_FLOAT(
-        0.0F, // NOLINT
-        callback_data->last_point_clouds[0].radar_points[num_points].radar_relative_radial_velocity_m_s);
+    TEST_ASSERT_EQUAL_FLOAT( // NOLINT
+        0.0F, callback_data->last_point_clouds[0].radar_points[num_points].radar_relative_radial_velocity_m_s);
     TEST_ASSERT_EQUAL_FLOAT(0.0F, // NOLINT
                             callback_data->last_point_clouds[0].radar_points[num_points].signal_to_noise_ratio);
 
@@ -502,8 +500,8 @@ static void test_receives_single_radar_point_cloud_from_2_radars(void)
                                 callback_data->last_point_clouds[i].radar_points[num_points - 1].y_meters);
         TEST_ASSERT_EQUAL_FLOAT(22.4543F, // NOLINT
                                 callback_data->last_point_clouds[i].radar_points[num_points - 1].z_meters);
-        TEST_ASSERT_EQUAL_FLOAT(
-            -1.95574F, // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT( // NOLINT
+            -1.95574F,
             callback_data->last_point_clouds[i].radar_points[num_points - 1].radar_relative_radial_velocity_m_s);
         TEST_ASSERT_EQUAL_FLOAT(42.63091F, // NOLINT
                                 callback_data->last_point_clouds[i].radar_points[num_points - 1].signal_to_noise_ratio);
@@ -515,9 +513,8 @@ static void test_receives_single_radar_point_cloud_from_2_radars(void)
                                 callback_data->last_point_clouds[i].radar_points[num_points].y_meters);
         TEST_ASSERT_EQUAL_FLOAT(0.0F, // NOLINT
                                 callback_data->last_point_clouds[i].radar_points[num_points].z_meters);
-        TEST_ASSERT_EQUAL_FLOAT(
-            0.0F, // NOLINT
-            callback_data->last_point_clouds[i].radar_points[num_points].radar_relative_radial_velocity_m_s);
+        TEST_ASSERT_EQUAL_FLOAT( // NOLINT
+            0.0F, callback_data->last_point_clouds[i].radar_points[num_points].radar_relative_radial_velocity_m_s);
         TEST_ASSERT_EQUAL_FLOAT(0.0F, // NOLINT
                                 callback_data->last_point_clouds[i].radar_points[num_points].signal_to_noise_ratio);
     }

--- a/test/c_99/src/test_core.c
+++ b/test/c_99/src/test_core.c
@@ -187,7 +187,8 @@ static int32_t make_test_pointcloud(const uint32_t frame_index, const uint64_t t
                 provizio_set_protocol_field_float(&packet.radar_points[j].z_meters, z_meters);
                 provizio_set_protocol_field_float(&packet.radar_points[j].radar_relative_radial_velocity_m_s, velocity);
                 provizio_set_protocol_field_float(&packet.radar_points[j].signal_to_noise_ratio, signal_to_noise_ratio);
-                provizio_set_protocol_field_float(&packet.radar_points[j].ground_relative_radial_velocity_m_s, nanf(""));
+                provizio_set_protocol_field_float(&packet.radar_points[j].ground_relative_radial_velocity_m_s,
+                                                  nanf(""));
             }
 
             const int32_t result = callback(&packet, user_data);
@@ -408,8 +409,9 @@ static void test_receives_single_radar_point_cloud_from_single_radar(void)
                             callback_data->last_point_clouds[0].radar_points[num_points - 1].y_meters);
     TEST_ASSERT_EQUAL_FLOAT(22.4543F, // NOLINT
                             callback_data->last_point_clouds[0].radar_points[num_points - 1].z_meters);
-    TEST_ASSERT_EQUAL_FLOAT(-1.95574F, // NOLINT
-                            callback_data->last_point_clouds[0].radar_points[num_points - 1].radar_relative_radial_velocity_m_s);
+    TEST_ASSERT_EQUAL_FLOAT(
+        -1.95574F, // NOLINT
+        callback_data->last_point_clouds[0].radar_points[num_points - 1].radar_relative_radial_velocity_m_s);
     TEST_ASSERT_EQUAL_FLOAT(42.63091F, // NOLINT
                             callback_data->last_point_clouds[0].radar_points[num_points - 1].signal_to_noise_ratio);
 
@@ -420,8 +422,9 @@ static void test_receives_single_radar_point_cloud_from_single_radar(void)
                             callback_data->last_point_clouds[0].radar_points[num_points].y_meters);
     TEST_ASSERT_EQUAL_FLOAT(0.0F, // NOLINT
                             callback_data->last_point_clouds[0].radar_points[num_points].z_meters);
-    TEST_ASSERT_EQUAL_FLOAT(0.0F, // NOLINT
-                            callback_data->last_point_clouds[0].radar_points[num_points].radar_relative_radial_velocity_m_s);
+    TEST_ASSERT_EQUAL_FLOAT(
+        0.0F, // NOLINT
+        callback_data->last_point_clouds[0].radar_points[num_points].radar_relative_radial_velocity_m_s);
     TEST_ASSERT_EQUAL_FLOAT(0.0F, // NOLINT
                             callback_data->last_point_clouds[0].radar_points[num_points].signal_to_noise_ratio);
 
@@ -499,8 +502,9 @@ static void test_receives_single_radar_point_cloud_from_2_radars(void)
                                 callback_data->last_point_clouds[i].radar_points[num_points - 1].y_meters);
         TEST_ASSERT_EQUAL_FLOAT(22.4543F, // NOLINT
                                 callback_data->last_point_clouds[i].radar_points[num_points - 1].z_meters);
-        TEST_ASSERT_EQUAL_FLOAT(-1.95574F, // NOLINT
-                                callback_data->last_point_clouds[i].radar_points[num_points - 1].radar_relative_radial_velocity_m_s);
+        TEST_ASSERT_EQUAL_FLOAT(
+            -1.95574F, // NOLINT
+            callback_data->last_point_clouds[i].radar_points[num_points - 1].radar_relative_radial_velocity_m_s);
         TEST_ASSERT_EQUAL_FLOAT(42.63091F, // NOLINT
                                 callback_data->last_point_clouds[i].radar_points[num_points - 1].signal_to_noise_ratio);
 
@@ -511,8 +515,9 @@ static void test_receives_single_radar_point_cloud_from_2_radars(void)
                                 callback_data->last_point_clouds[i].radar_points[num_points].y_meters);
         TEST_ASSERT_EQUAL_FLOAT(0.0F, // NOLINT
                                 callback_data->last_point_clouds[i].radar_points[num_points].z_meters);
-        TEST_ASSERT_EQUAL_FLOAT(0.0F, // NOLINT
-                                callback_data->last_point_clouds[i].radar_points[num_points].radar_relative_radial_velocity_m_s);
+        TEST_ASSERT_EQUAL_FLOAT(
+            0.0F, // NOLINT
+            callback_data->last_point_clouds[i].radar_points[num_points].radar_relative_radial_velocity_m_s);
         TEST_ASSERT_EQUAL_FLOAT(0.0F, // NOLINT
                                 callback_data->last_point_clouds[i].radar_points[num_points].signal_to_noise_ratio);
     }

--- a/test/c_99/src/test_core.c
+++ b/test/c_99/src/test_core.c
@@ -185,8 +185,9 @@ static int32_t make_test_pointcloud(const uint32_t frame_index, const uint64_t t
                 provizio_set_protocol_field_float(&packet.radar_points[j].x_meters, x_meters);
                 provizio_set_protocol_field_float(&packet.radar_points[j].y_meters, y_meters);
                 provizio_set_protocol_field_float(&packet.radar_points[j].z_meters, z_meters);
-                provizio_set_protocol_field_float(&packet.radar_points[j].velocity_m_s, velocity);
+                provizio_set_protocol_field_float(&packet.radar_points[j].radar_relative_radial_velocity_m_s, velocity);
                 provizio_set_protocol_field_float(&packet.radar_points[j].signal_to_noise_ratio, signal_to_noise_ratio);
+                provizio_set_protocol_field_float(&packet.radar_points[j].ground_relative_radial_velocity_m_s, nanf(""));
             }
 
             const int32_t result = callback(&packet, user_data);
@@ -396,7 +397,7 @@ static void test_receives_single_radar_point_cloud_from_single_radar(void)
     TEST_ASSERT_EQUAL_FLOAT(11.97F, // NOLINT
                             callback_data->last_point_clouds[0].radar_points[0].z_meters);
     TEST_ASSERT_EQUAL_FLOAT(5.31F, // NOLINT
-                            callback_data->last_point_clouds[0].radar_points[0].velocity_m_s);
+                            callback_data->last_point_clouds[0].radar_points[0].radar_relative_radial_velocity_m_s);
     TEST_ASSERT_EQUAL_FLOAT(29.73F, // NOLINT
                             callback_data->last_point_clouds[0].radar_points[0].signal_to_noise_ratio);
 
@@ -408,7 +409,7 @@ static void test_receives_single_radar_point_cloud_from_single_radar(void)
     TEST_ASSERT_EQUAL_FLOAT(22.4543F, // NOLINT
                             callback_data->last_point_clouds[0].radar_points[num_points - 1].z_meters);
     TEST_ASSERT_EQUAL_FLOAT(-1.95574F, // NOLINT
-                            callback_data->last_point_clouds[0].radar_points[num_points - 1].velocity_m_s);
+                            callback_data->last_point_clouds[0].radar_points[num_points - 1].radar_relative_radial_velocity_m_s);
     TEST_ASSERT_EQUAL_FLOAT(42.63091F, // NOLINT
                             callback_data->last_point_clouds[0].radar_points[num_points - 1].signal_to_noise_ratio);
 
@@ -420,7 +421,7 @@ static void test_receives_single_radar_point_cloud_from_single_radar(void)
     TEST_ASSERT_EQUAL_FLOAT(0.0F, // NOLINT
                             callback_data->last_point_clouds[0].radar_points[num_points].z_meters);
     TEST_ASSERT_EQUAL_FLOAT(0.0F, // NOLINT
-                            callback_data->last_point_clouds[0].radar_points[num_points].velocity_m_s);
+                            callback_data->last_point_clouds[0].radar_points[num_points].radar_relative_radial_velocity_m_s);
     TEST_ASSERT_EQUAL_FLOAT(0.0F, // NOLINT
                             callback_data->last_point_clouds[0].radar_points[num_points].signal_to_noise_ratio);
 
@@ -487,7 +488,7 @@ static void test_receives_single_radar_point_cloud_from_2_radars(void)
         TEST_ASSERT_EQUAL_FLOAT(11.97F, // NOLINT
                                 callback_data->last_point_clouds[i].radar_points[0].z_meters);
         TEST_ASSERT_EQUAL_FLOAT(5.31F, // NOLINT
-                                callback_data->last_point_clouds[i].radar_points[0].velocity_m_s);
+                                callback_data->last_point_clouds[i].radar_points[0].radar_relative_radial_velocity_m_s);
         TEST_ASSERT_EQUAL_FLOAT(29.73F, // NOLINT
                                 callback_data->last_point_clouds[i].radar_points[0].signal_to_noise_ratio);
 
@@ -499,7 +500,7 @@ static void test_receives_single_radar_point_cloud_from_2_radars(void)
         TEST_ASSERT_EQUAL_FLOAT(22.4543F, // NOLINT
                                 callback_data->last_point_clouds[i].radar_points[num_points - 1].z_meters);
         TEST_ASSERT_EQUAL_FLOAT(-1.95574F, // NOLINT
-                                callback_data->last_point_clouds[i].radar_points[num_points - 1].velocity_m_s);
+                                callback_data->last_point_clouds[i].radar_points[num_points - 1].radar_relative_radial_velocity_m_s);
         TEST_ASSERT_EQUAL_FLOAT(42.63091F, // NOLINT
                                 callback_data->last_point_clouds[i].radar_points[num_points - 1].signal_to_noise_ratio);
 
@@ -511,7 +512,7 @@ static void test_receives_single_radar_point_cloud_from_2_radars(void)
         TEST_ASSERT_EQUAL_FLOAT(0.0F, // NOLINT
                                 callback_data->last_point_clouds[i].radar_points[num_points].z_meters);
         TEST_ASSERT_EQUAL_FLOAT(0.0F, // NOLINT
-                                callback_data->last_point_clouds[i].radar_points[num_points].velocity_m_s);
+                                callback_data->last_point_clouds[i].radar_points[num_points].radar_relative_radial_velocity_m_s);
         TEST_ASSERT_EQUAL_FLOAT(0.0F, // NOLINT
                                 callback_data->last_point_clouds[i].radar_points[num_points].signal_to_noise_ratio);
     }

--- a/test/c_99/src/test_radar_point_cloud.c
+++ b/test/c_99/src/test_radar_point_cloud.c
@@ -35,9 +35,7 @@ typedef struct provizio_radar_point_protocol_v1
     float signal_to_noise_ratio;
 } provizio_radar_point_protocol_v1;
 
-#define PROVIZIO__MAX_RADAR_POINTS_PER_UDP_PACKET_PROTOCOL_V1                                                          \
-    ((uint16_t)((PROVIZIO__MAX_PAYLOAD_PER_UDP_PACKET_BYTES - sizeof(provizio_radar_point_cloud_packet_header)) /      \
-                sizeof(provizio_radar_point_protocol_v1)))
+#define PROVIZIO__MAX_RADAR_POINTS_PER_UDP_PACKET_PROTOCOL_V1 72
 
 typedef struct provizio_radar_point_cloud_packet_protocol_v1
 {
@@ -45,29 +43,6 @@ typedef struct provizio_radar_point_cloud_packet_protocol_v1
     provizio_radar_point_protocol_v1 radar_points[PROVIZIO__MAX_RADAR_POINTS_PER_UDP_PACKET_PROTOCOL_V1];
 } provizio_radar_point_cloud_packet_protocol_v1;
 #pragma pack(pop)
-
-#if defined(__cplusplus) && __cplusplus >= 201103L
-static_assert(offsetof(provizio_radar_point_cloud_packet_protocol_v1, header) == 0,
-              "Unexpected position of header in provizio_radar_point_cloud_packet_protocol_v1");
-static_assert(offsetof(provizio_radar_point_cloud_packet_protocol_v1, radar_points) ==
-                  sizeof(provizio_radar_point_cloud_packet_header),
-              "Unexpected position of radar_points in provizio_radar_point_cloud_packet");
-static_assert(sizeof(provizio_radar_point_cloud_packet_protocol_v1) ==
-                  sizeof(provizio_radar_point_cloud_packet_header) +
-                      sizeof(provizio_radar_point_v1_protocol) * PROVIZIO__MAX_RADAR_POINTS_PER_UDP_PACKET_PROTOCOL_V1,
-              "Unexpected size of provizio_radar_point_cloud_packet_protocol_v1");
-static_assert(offsetof(provizio_radar_point_v1_protocol, x_meters) == 0,
-              "Unexpected position of x_meters in provizio_radar_point_v1_protocol");
-static_assert(offsetof(provizio_radar_point_v1_protocol, y_meters) == 4,
-              "Unexpected position of y_meters in provizio_radar_point_v1_protocol");
-static_assert(offsetof(provizio_radar_point_v1_protocol, z_meters) == 8,
-              "Unexpected position of z_meters in provizio_radar_point_v1_protocol");
-static_assert(offsetof(provizio_radar_point_v1_protocol, radar_relative_radial_velocity_m_s) == 12,
-              "Unexpected position of radar_relative_radial_velocity_m_s in provizio_radar_point_v1_protocol");
-static_assert(offsetof(provizio_radar_point_v1_protocol, signal_to_noise_ratio) == 16,
-              "Unexpected position of signal_to_noise_ratio in provizio_radar_point_v1_protocol");
-static_assert(sizeof(provizio_radar_point_v1_protocol) == 20, "Unexpected size of provizio_radar_point_v1_protocol");
-#endif // defined(__cplusplus) && __cplusplus >= 201103L
 
 enum
 {
@@ -611,6 +586,19 @@ static void test_provizio_handle_possible_radars_point_cloud_packet_ground_veloc
     free(callback_data);
 }
 
+static void test_provizio_check_radar_point_cloud_packet_v1(void)
+{
+    TEST_ASSERT_EQUAL_INT32(0, offsetof(provizio_radar_point_cloud_packet_protocol_v1, header));
+    TEST_ASSERT_EQUAL_INT32(24, offsetof(provizio_radar_point_cloud_packet_protocol_v1, radar_points));
+    TEST_ASSERT_EQUAL_INT32(1464, sizeof(provizio_radar_point_cloud_packet_protocol_v1));
+    TEST_ASSERT_EQUAL_INT32(0, offsetof(provizio_radar_point_protocol_v1, x_meters));
+    TEST_ASSERT_EQUAL_INT32(4, offsetof(provizio_radar_point_protocol_v1, y_meters));
+    TEST_ASSERT_EQUAL_INT32(8, offsetof(provizio_radar_point_protocol_v1, z_meters));
+    TEST_ASSERT_EQUAL_INT32(12, offsetof(provizio_radar_point_protocol_v1, radar_relative_radial_velocity_m_s));
+    TEST_ASSERT_EQUAL_INT32(16, offsetof(provizio_radar_point_protocol_v1, signal_to_noise_ratio));
+    TEST_ASSERT_EQUAL_INT32(20, sizeof(provizio_radar_point_protocol_v1));
+}
+
 static void test_provizio_handle_possible_radars_point_cloud_packet_v1(void)
 {
     const uint32_t frame_index = 1000;
@@ -685,6 +673,7 @@ int provizio_run_test_radar_point_cloud(void)
     RUN_TEST(test_provizio_handle_possible_radars_point_cloud_packet_ok);
     RUN_TEST(test_provizio_handle_possible_radars_point_cloud_packet_ground_velocity);
     RUN_TEST(test_provizio_handle_possible_radars_point_cloud_packet_v1);
+    RUN_TEST(test_provizio_check_radar_point_cloud_packet_v1);
 
     return UNITY_END();
 }

--- a/test/c_99/src/test_radar_point_cloud.c
+++ b/test/c_99/src/test_radar_point_cloud.c
@@ -35,7 +35,7 @@ typedef struct provizio_radar_point_protocol_v1
     float signal_to_noise_ratio;
 } provizio_radar_point_protocol_v1;
 
-#define PROVIZIO__MAX_RADAR_POINTS_PER_UDP_PACKET_PROTOCOL_V1 ((uint16_t) 72)
+#define PROVIZIO__MAX_RADAR_POINTS_PER_UDP_PACKET_PROTOCOL_V1 ((uint16_t)72)
 
 typedef struct provizio_radar_point_cloud_packet_protocol_v1
 {

--- a/test/c_99/src/test_radar_point_cloud.c
+++ b/test/c_99/src/test_radar_point_cloud.c
@@ -118,7 +118,7 @@ static int32_t create_test_pointcloud_packet(provizio_radar_point_cloud_packet *
             provizio_set_protocol_field_float(&packet->radar_points[j].z_meters, z_meters);
             provizio_set_protocol_field_float(&packet->radar_points[j].radar_relative_radial_velocity_m_s, velocity);
             provizio_set_protocol_field_float(&packet->radar_points[j].signal_to_noise_ratio, signal_to_noise_ratio);
-            provizio_set_protocol_field_float(&packet->radar_points[j].ground_relative_radial_velocity_m_s, velocity);
+            provizio_set_protocol_field_float(&packet->radar_points[j].ground_relative_radial_velocity_m_s, -velocity);
         }
         else
         {
@@ -508,7 +508,7 @@ static void test_provizio_handle_possible_radars_point_cloud_packet_ground_veloc
         {
             TEST_ASSERT_EQUAL_FLOAT( // NOLINT
                 callback_data->last_point_clouds[0].radar_points[j].radar_relative_radial_velocity_m_s,
-                callback_data->last_point_clouds[0].radar_points[j].ground_relative_radial_velocity_m_s);
+                callback_data->last_point_clouds[0].radar_points[j].ground_relative_radial_velocity_m_s * -1);
         }
 
         // Test Point Cloud Packet UDP Protocol Version 1

--- a/test/c_99/src/test_radar_point_cloud.c
+++ b/test/c_99/src/test_radar_point_cloud.c
@@ -35,7 +35,7 @@ typedef struct provizio_radar_point_protocol_v1
     float signal_to_noise_ratio;
 } provizio_radar_point_protocol_v1;
 
-#define PROVIZIO__MAX_RADAR_POINTS_PER_UDP_PACKET_PROTOCOL_V1 72
+#define PROVIZIO__MAX_RADAR_POINTS_PER_UDP_PACKET_PROTOCOL_V1 ((uint16_t) 72)
 
 typedef struct provizio_radar_point_cloud_packet_protocol_v1
 {

--- a/test/c_99/src/test_radar_point_cloud.c
+++ b/test/c_99/src/test_radar_point_cloud.c
@@ -627,7 +627,7 @@ static void test_provizio_handle_possible_radars_point_cloud_packet_v1(void)
 
         // test greater than max allowed radar points in udp packet for protocol version 1 (code coverage)
         packet.header.frame_index += 1;
-        packet.header.num_points_in_packet = 73;
+        packet.header.num_points_in_packet += 1;
 
         TEST_ASSERT_EQUAL_INT32( // NOLINT
             PROVIZIO_E_SKIPPED,

--- a/test/c_99/src/test_radar_point_cloud.c
+++ b/test/c_99/src/test_radar_point_cloud.c
@@ -611,8 +611,6 @@ static void test_provizio_handle_possible_radars_point_cloud_packet_v1(void)
         struct provizio_radar_point_cloud_packet_v1 packet;
         memset(&packet, 0, sizeof(packet));
 
-        // Test Point Cloud Packet UDP Protocol Version 1
-
         TEST_ASSERT_EQUAL_INT32(0, // NOLINT
                                 create_test_pointcloud_packet_v1(&packet, frame_index, timestamp, radar_position_ids[i],
                                                                  radar_modes[i], num_points, points_in_packet));
@@ -626,6 +624,14 @@ static void test_provizio_handle_possible_radars_point_cloud_packet_v1(void)
             TEST_ASSERT_EQUAL_FLOAT( // NOLINT
                 nanf(""), callback_data->last_point_clouds[0].radar_points[j].ground_relative_radial_velocity_m_s);
         }
+
+        // test greater than max allowed radar points in udp packet for protocol version 1 (code coverage)
+        packet.header.frame_index += 1;
+        packet.header.num_points_in_packet = 73;
+
+        TEST_ASSERT_EQUAL_INT32( // NOLINT
+            PROVIZIO_E_SKIPPED, provizio_handle_possible_radars_point_cloud_packet(
+                   api_contexts, num_contexts, &packet, provizio_radar_point_cloud_packet_size(&packet.header)));
     }
 
     free(api_contexts);

--- a/test/c_99/src/test_radar_point_cloud.c
+++ b/test/c_99/src/test_radar_point_cloud.c
@@ -506,7 +506,7 @@ static void test_provizio_handle_possible_radars_point_cloud_packet_ground_veloc
 
         for (uint16_t j = 0; j < points_in_packet; ++j)
         {
-            TEST_ASSERT_EQUAL_FLOAT(
+            TEST_ASSERT_EQUAL_FLOAT( // NOLINT
                 callback_data->last_point_clouds[0].radar_points[j].radar_relative_radial_velocity_m_s,
                 callback_data->last_point_clouds[0].radar_points[j].ground_relative_radial_velocity_m_s);
         }
@@ -525,7 +525,7 @@ static void test_provizio_handle_possible_radars_point_cloud_packet_ground_veloc
 
         for (uint16_t j = 0; j < points_in_packet; ++j)
         {
-            TEST_ASSERT_EQUAL_FLOAT(
+            TEST_ASSERT_EQUAL_FLOAT( // NOLINT
                 nanf(""), callback_data->last_point_clouds[0].radar_points[j].ground_relative_radial_velocity_m_s);
         }
     }

--- a/test/c_99/src/test_radar_point_cloud.c
+++ b/test/c_99/src/test_radar_point_cloud.c
@@ -59,6 +59,87 @@ void test_provizio_radar_point_cloud_callback(const provizio_radar_point_cloud *
     data->last_point_clouds[0] = *point_cloud;
 }
 
+static int32_t create_test_pointcloud_packet(
+        provizio_radar_point_cloud_packet *packet,
+        const uint16_t protocol_version,
+        const uint32_t frame_index,
+        const uint64_t timestamp,
+        const uint16_t radar_position_id,
+        const uint16_t radar_mode,
+        const uint16_t total_points_in_frame,
+        const uint16_t num_points_in_packet)
+{
+    const float x_meters_min = -100.0F;
+    const float x_meters_max = 100.0F;
+    const float x_meters_step = 12.33F;
+    const float y_meters_min = -15.0F;
+    const float y_meters_max = 15.0F;
+    const float y_meters_step = 1.17F;
+    const float z_meters_min = -2.0F;
+    const float z_meters_max = 25.0F;
+    const float z_meters_step = 0.47F;
+    const float velocity_min = -30.0F;
+    const float velocity_max = 30.0F;
+    const float velocity_step = 5.31F;
+    const float signal_to_noise_ratio_min = 2.0F;
+    const float signal_to_noise_ratio_max = 50.0F;
+    const float signal_to_noise_ratio_step = 3.73F;
+    const float half = 0.5F;
+
+    float x_meters = (x_meters_min + x_meters_max) * half;
+    float y_meters = (y_meters_min + y_meters_max) * half;
+    float z_meters = (z_meters_min + z_meters_max) * half;
+    float velocity = (velocity_min + velocity_max) * half;
+    float signal_to_noise_ratio = (signal_to_noise_ratio_min + signal_to_noise_ratio_max) * half;
+
+    provizio_radar_point_v1_protocol *v1_radar_points = (provizio_radar_point_v1_protocol *) packet->radar_points;
+
+    memset(packet, 0, sizeof(provizio_radar_point_cloud_packet));
+
+    provizio_set_protocol_field_uint16_t(&packet->header.protocol_header.packet_type,
+                                         PROVIZIO__RADAR_API_POINT_CLOUD_PACKET_TYPE);
+    provizio_set_protocol_field_uint16_t(&packet->header.protocol_header.protocol_version,
+                                         protocol_version);
+    provizio_set_protocol_field_uint32_t(&packet->header.frame_index, frame_index);
+    provizio_set_protocol_field_uint64_t(&packet->header.timestamp, timestamp);
+    provizio_set_protocol_field_uint16_t(&packet->header.radar_position_id, radar_position_id);
+    provizio_set_protocol_field_uint16_t(&packet->header.radar_mode, radar_mode);
+    provizio_set_protocol_field_uint16_t(&packet->header.total_points_in_frame, total_points_in_frame);
+    provizio_set_protocol_field_uint16_t(&packet->header.num_points_in_packet, num_points_in_packet);
+
+#pragma unroll(8)
+    for (uint16_t j = 0; j < num_points_in_packet; ++j) // NOLINT: The loop is just fine
+    {
+#define PROVIZIO__NEXT_TEST_VALUE(v) ((v##_min) + fmodf((v) + (v##_step) - (v##_min), (v##_max) - (v##_min)))
+        x_meters = PROVIZIO__NEXT_TEST_VALUE(x_meters);
+        y_meters = PROVIZIO__NEXT_TEST_VALUE(y_meters);
+        z_meters = PROVIZIO__NEXT_TEST_VALUE(z_meters);
+        velocity = PROVIZIO__NEXT_TEST_VALUE(velocity);
+        signal_to_noise_ratio = PROVIZIO__NEXT_TEST_VALUE(signal_to_noise_ratio);
+#undef PROVIZIO__NEXT_TEST_VALUE
+
+        if(protocol_version >= 2)
+        {
+            provizio_set_protocol_field_float(&packet->radar_points[j].x_meters, x_meters);
+            provizio_set_protocol_field_float(&packet->radar_points[j].y_meters, y_meters);
+            provizio_set_protocol_field_float(&packet->radar_points[j].z_meters, z_meters);
+            provizio_set_protocol_field_float(&packet->radar_points[j].radar_relative_radial_velocity_m_s, velocity);
+            provizio_set_protocol_field_float(&packet->radar_points[j].signal_to_noise_ratio, signal_to_noise_ratio);
+            provizio_set_protocol_field_float(&packet->radar_points[j].ground_relative_radial_velocity_m_s, velocity);
+        }
+        else
+        {
+            provizio_set_protocol_field_float(&v1_radar_points[j].x_meters, x_meters);
+            provizio_set_protocol_field_float(&v1_radar_points[j].y_meters, y_meters);
+            provizio_set_protocol_field_float(&v1_radar_points[j].z_meters, z_meters);
+            provizio_set_protocol_field_float(&v1_radar_points[j].radar_relative_radial_velocity_m_s, velocity);
+            provizio_set_protocol_field_float(&v1_radar_points[j].signal_to_noise_ratio, signal_to_noise_ratio);
+        }
+    }
+
+    return 0;
+}
+
 static void test_provizio_radar_point_cloud_packet_size(void)
 {
     provizio_radar_point_cloud_packet_header header;
@@ -364,8 +445,10 @@ static void test_provizio_handle_possible_radars_point_cloud_packet_ok(void)
     const uint16_t num_points = 11;
     const uint16_t points_in_packet = 10;
 
-    provizio_radar_point_cloud_api_context api_contexts[2];
-    const size_t num_contexts = sizeof(api_contexts) / sizeof(api_contexts[0]);
+    const size_t num_contexts = 2;
+    provizio_radar_point_cloud_api_context *api_contexts =
+        (provizio_radar_point_cloud_api_context *)malloc(sizeof(provizio_radar_point_cloud_api_context) * num_contexts);
+    TEST_ASSERT_NOT_EQUAL(NULL, api_contexts);
     provizio_radar_point_cloud_api_contexts_init(NULL, NULL, api_contexts, num_contexts);
 
     for (size_t i = 0; i < num_contexts; ++i) // NOLINT: Don't unroll the loop
@@ -383,13 +466,73 @@ static void test_provizio_handle_possible_radars_point_cloud_packet_ok(void)
         provizio_set_protocol_field_uint16_t(&packet.header.total_points_in_frame, num_points);
         provizio_set_protocol_field_uint16_t(&packet.header.num_points_in_packet, points_in_packet);
 
-        provizio_radar_point_cloud_api_context api_context;
-        provizio_radar_point_cloud_api_context_init(NULL, NULL, &api_context);
-
         TEST_ASSERT_EQUAL_INT32(
             0, provizio_handle_possible_radars_point_cloud_packet(
                    api_contexts, num_contexts, &packet, provizio_radar_point_cloud_packet_size(&packet.header)));
     }
+    free(api_contexts);
+}
+
+static void test_provizio_handle_possible_radars_point_cloud_packet_ground_velocity(void)
+{
+    const uint32_t frame_index = 1000;
+    const uint64_t timestamp = 0x0123456789abcdef;
+    const uint16_t radar_position_ids[2] = {provizio_radar_position_rear_left, provizio_radar_position_rear_right};
+    const uint16_t radar_modes[2] = {provizio_radar_mode_long_range, provizio_radar_mode_medium_range};
+    const uint16_t num_points = 10;
+    const uint16_t points_in_packet = 10;
+
+    const size_t num_contexts = 2;
+    provizio_radar_point_cloud_api_context *api_contexts =
+        (provizio_radar_point_cloud_api_context *)malloc(sizeof(provizio_radar_point_cloud_api_context) * num_contexts);
+    TEST_ASSERT_NOT_EQUAL(NULL, api_contexts);
+
+    test_provizio_radar_point_cloud_callback_data *callback_data =
+        (test_provizio_radar_point_cloud_callback_data *)malloc(sizeof(test_provizio_radar_point_cloud_callback_data));
+    TEST_ASSERT_NOT_EQUAL(NULL, callback_data);
+    memset(callback_data, 0, sizeof(test_provizio_radar_point_cloud_callback_data));
+
+    provizio_radar_point_cloud_api_contexts_init(&test_provizio_radar_point_cloud_callback, callback_data, api_contexts, num_contexts);
+
+    for (size_t i = 0; i < num_contexts; ++i) // NOLINT: Don't unroll the loop
+    {
+        provizio_radar_point_cloud_packet packet;
+        memset(&packet, 0, sizeof(packet));
+
+        // Test Point Cloud Packet UDP Protocol Version 2
+
+        TEST_ASSERT_EQUAL_INT32(0,  // NOLINT
+            create_test_pointcloud_packet(&packet, 2, frame_index, timestamp, radar_position_ids[i], radar_modes[i], num_points, points_in_packet));
+
+        TEST_ASSERT_EQUAL_INT32(0,  // NOLINT
+            provizio_handle_possible_radars_point_cloud_packet(
+                   api_contexts, num_contexts, &packet, provizio_radar_point_cloud_packet_size(&packet.header)));
+
+        for (uint16_t j = 0; j < points_in_packet; ++j)
+        {
+            TEST_ASSERT_EQUAL_FLOAT(callback_data->last_point_clouds[0].radar_points[j].radar_relative_radial_velocity_m_s, callback_data->last_point_clouds[0].radar_points[j].ground_relative_radial_velocity_m_s);
+            //printf("%f :: %f\n", callback_data->last_point_clouds[0].radar_points[j].radar_relative_radial_velocity_m_s, callback_data->last_point_clouds[0].radar_points[j].ground_relative_radial_velocity_m_s);
+        }
+
+        // Test Point Cloud Packet UDP Protocol Version 1
+
+        TEST_ASSERT_EQUAL_INT32(0,  // NOLINT
+            create_test_pointcloud_packet(&packet, 1, frame_index + 1, timestamp, radar_position_ids[i], radar_modes[i], num_points, points_in_packet));
+
+        TEST_ASSERT_EQUAL_INT32(0,  // NOLINT
+            provizio_handle_possible_radars_point_cloud_packet(
+                   api_contexts, num_contexts, &packet, provizio_radar_point_cloud_packet_size(&packet.header)));
+
+        for (uint16_t j = 0; j < points_in_packet; ++j)
+        {
+            TEST_ASSERT_EQUAL_FLOAT(nanf(""), callback_data->last_point_clouds[0].radar_points[j].ground_relative_radial_velocity_m_s);
+            //printf("%f :: %f\n", callback_data->last_point_clouds[0].radar_points[j].radar_relative_radial_velocity_m_s, callback_data->last_point_clouds[0].radar_points[j].ground_relative_radial_velocity_m_s);
+        }
+
+    }
+
+    free(api_contexts);
+    free(callback_data);
 }
 
 int provizio_run_test_radar_point_cloud(void)
@@ -409,6 +552,7 @@ int provizio_run_test_radar_point_cloud(void)
     RUN_TEST(test_provizio_handle_possible_radar_point_cloud_packet_wrong_protocol_version);
     RUN_TEST(test_provizio_handle_possible_radar_point_cloud_packet_ok);
     RUN_TEST(test_provizio_handle_possible_radars_point_cloud_packet_ok);
+    RUN_TEST(test_provizio_handle_possible_radars_point_cloud_packet_ground_velocity);
 
     return UNITY_END();
 }

--- a/test/c_99/src/test_radar_point_cloud.c
+++ b/test/c_99/src/test_radar_point_cloud.c
@@ -58,15 +58,10 @@ void test_provizio_radar_point_cloud_callback(const provizio_radar_point_cloud *
     data->last_point_clouds[0] = *point_cloud;
 }
 
-static int32_t create_test_pointcloud_packet(
-        provizio_radar_point_cloud_packet *packet,
-        const uint16_t protocol_version,
-        const uint32_t frame_index,
-        const uint64_t timestamp,
-        const uint16_t radar_position_id,
-        const uint16_t radar_mode,
-        const uint16_t total_points_in_frame,
-        const uint16_t num_points_in_packet)
+static int32_t create_test_pointcloud_packet(provizio_radar_point_cloud_packet *packet, const uint16_t protocol_version,
+                                             const uint32_t frame_index, const uint64_t timestamp,
+                                             const uint16_t radar_position_id, const uint16_t radar_mode,
+                                             const uint16_t total_points_in_frame, const uint16_t num_points_in_packet)
 {
     const float x_meters_min = -100.0F;
     const float x_meters_max = 100.0F;
@@ -91,14 +86,13 @@ static int32_t create_test_pointcloud_packet(
     float velocity = (velocity_min + velocity_max) * half;
     float signal_to_noise_ratio = (signal_to_noise_ratio_min + signal_to_noise_ratio_max) * half;
 
-    provizio_radar_point_v1_protocol *v1_radar_points = (provizio_radar_point_v1_protocol *) packet->radar_points;
+    provizio_radar_point_v1_protocol *v1_radar_points = (provizio_radar_point_v1_protocol *)packet->radar_points;
 
     memset(packet, 0, sizeof(provizio_radar_point_cloud_packet));
 
     provizio_set_protocol_field_uint16_t(&packet->header.protocol_header.packet_type,
                                          PROVIZIO__RADAR_API_POINT_CLOUD_PACKET_TYPE);
-    provizio_set_protocol_field_uint16_t(&packet->header.protocol_header.protocol_version,
-                                         protocol_version);
+    provizio_set_protocol_field_uint16_t(&packet->header.protocol_header.protocol_version, protocol_version);
     provizio_set_protocol_field_uint32_t(&packet->header.frame_index, frame_index);
     provizio_set_protocol_field_uint64_t(&packet->header.timestamp, timestamp);
     provizio_set_protocol_field_uint16_t(&packet->header.radar_position_id, radar_position_id);
@@ -117,7 +111,7 @@ static int32_t create_test_pointcloud_packet(
         signal_to_noise_ratio = PROVIZIO__NEXT_TEST_VALUE(signal_to_noise_ratio);
 #undef PROVIZIO__NEXT_TEST_VALUE
 
-        if(protocol_version >= 2)
+        if (protocol_version >= 2)
         {
             provizio_set_protocol_field_float(&packet->radar_points[j].x_meters, x_meters);
             provizio_set_protocol_field_float(&packet->radar_points[j].y_meters, y_meters);
@@ -491,7 +485,8 @@ static void test_provizio_handle_possible_radars_point_cloud_packet_ground_veloc
     TEST_ASSERT_NOT_EQUAL(NULL, callback_data);
     memset(callback_data, 0, sizeof(test_provizio_radar_point_cloud_callback_data));
 
-    provizio_radar_point_cloud_api_contexts_init(&test_provizio_radar_point_cloud_callback, callback_data, api_contexts, num_contexts);
+    provizio_radar_point_cloud_api_contexts_init(&test_provizio_radar_point_cloud_callback, callback_data, api_contexts,
+                                                 num_contexts);
 
     for (size_t i = 0; i < num_contexts; ++i) // NOLINT: Don't unroll the loop
     {
@@ -500,32 +495,39 @@ static void test_provizio_handle_possible_radars_point_cloud_packet_ground_veloc
 
         // Test Point Cloud Packet UDP Protocol Version 2
 
-        TEST_ASSERT_EQUAL_INT32(0,  // NOLINT
-            create_test_pointcloud_packet(&packet, 2, frame_index, timestamp, radar_position_ids[i], radar_modes[i], num_points, points_in_packet));
+        TEST_ASSERT_EQUAL_INT32(0, // NOLINT
+                                create_test_pointcloud_packet(&packet, 2, frame_index, timestamp, radar_position_ids[i],
+                                                              radar_modes[i], num_points, points_in_packet));
 
-        TEST_ASSERT_EQUAL_INT32(0,  // NOLINT
-            provizio_handle_possible_radars_point_cloud_packet(
-                   api_contexts, num_contexts, &packet, provizio_radar_point_cloud_packet_size(&packet.header)));
+        TEST_ASSERT_EQUAL_INT32(
+            0, // NOLINT
+            provizio_handle_possible_radars_point_cloud_packet(api_contexts, num_contexts, &packet,
+                                                               provizio_radar_point_cloud_packet_size(&packet.header)));
 
         for (uint16_t j = 0; j < points_in_packet; ++j)
         {
-            TEST_ASSERT_EQUAL_FLOAT(callback_data->last_point_clouds[0].radar_points[j].radar_relative_radial_velocity_m_s, callback_data->last_point_clouds[0].radar_points[j].ground_relative_radial_velocity_m_s);
+            TEST_ASSERT_EQUAL_FLOAT(
+                callback_data->last_point_clouds[0].radar_points[j].radar_relative_radial_velocity_m_s,
+                callback_data->last_point_clouds[0].radar_points[j].ground_relative_radial_velocity_m_s);
         }
 
         // Test Point Cloud Packet UDP Protocol Version 1
 
-        TEST_ASSERT_EQUAL_INT32(0,  // NOLINT
-            create_test_pointcloud_packet(&packet, 1, frame_index + 1, timestamp, radar_position_ids[i], radar_modes[i], num_points, points_in_packet));
+        TEST_ASSERT_EQUAL_INT32(0, // NOLINT
+                                create_test_pointcloud_packet(&packet, 1, frame_index + 1, timestamp,
+                                                              radar_position_ids[i], radar_modes[i], num_points,
+                                                              points_in_packet));
 
-        TEST_ASSERT_EQUAL_INT32(0,  // NOLINT
-            provizio_handle_possible_radars_point_cloud_packet(
-                   api_contexts, num_contexts, &packet, provizio_radar_point_cloud_packet_size(&packet.header)));
+        TEST_ASSERT_EQUAL_INT32(
+            0, // NOLINT
+            provizio_handle_possible_radars_point_cloud_packet(api_contexts, num_contexts, &packet,
+                                                               provizio_radar_point_cloud_packet_size(&packet.header)));
 
         for (uint16_t j = 0; j < points_in_packet; ++j)
         {
-            TEST_ASSERT_EQUAL_FLOAT(nanf(""), callback_data->last_point_clouds[0].radar_points[j].ground_relative_radial_velocity_m_s);
+            TEST_ASSERT_EQUAL_FLOAT(
+                nanf(""), callback_data->last_point_clouds[0].radar_points[j].ground_relative_radial_velocity_m_s);
         }
-
     }
 
     free(api_contexts);

--- a/test/c_99/src/test_radar_point_cloud.c
+++ b/test/c_99/src/test_radar_point_cloud.c
@@ -630,8 +630,9 @@ static void test_provizio_handle_possible_radars_point_cloud_packet_v1(void)
         packet.header.num_points_in_packet = 73;
 
         TEST_ASSERT_EQUAL_INT32( // NOLINT
-            PROVIZIO_E_SKIPPED, provizio_handle_possible_radars_point_cloud_packet(
-                   api_contexts, num_contexts, &packet, provizio_radar_point_cloud_packet_size(&packet.header)));
+            PROVIZIO_E_SKIPPED,
+            provizio_handle_possible_radars_point_cloud_packet(api_contexts, num_contexts, &packet,
+                                                               provizio_radar_point_cloud_packet_size(&packet.header)));
     }
 
     free(api_contexts);

--- a/test/c_99/src/test_radar_point_cloud.c
+++ b/test/c_99/src/test_radar_point_cloud.c
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <math.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -511,7 +510,6 @@ static void test_provizio_handle_possible_radars_point_cloud_packet_ground_veloc
         for (uint16_t j = 0; j < points_in_packet; ++j)
         {
             TEST_ASSERT_EQUAL_FLOAT(callback_data->last_point_clouds[0].radar_points[j].radar_relative_radial_velocity_m_s, callback_data->last_point_clouds[0].radar_points[j].ground_relative_radial_velocity_m_s);
-            //printf("%f :: %f\n", callback_data->last_point_clouds[0].radar_points[j].radar_relative_radial_velocity_m_s, callback_data->last_point_clouds[0].radar_points[j].ground_relative_radial_velocity_m_s);
         }
 
         // Test Point Cloud Packet UDP Protocol Version 1
@@ -526,7 +524,6 @@ static void test_provizio_handle_possible_radars_point_cloud_packet_ground_veloc
         for (uint16_t j = 0; j < points_in_packet; ++j)
         {
             TEST_ASSERT_EQUAL_FLOAT(nanf(""), callback_data->last_point_clouds[0].radar_points[j].ground_relative_radial_velocity_m_s);
-            //printf("%f :: %f\n", callback_data->last_point_clouds[0].radar_points[j].radar_relative_radial_velocity_m_s, callback_data->last_point_clouds[0].radar_points[j].ground_relative_radial_velocity_m_s);
         }
 
     }

--- a/test/c_99/src/test_radar_point_cloud.c
+++ b/test/c_99/src/test_radar_point_cloud.c
@@ -25,6 +25,23 @@
 
 #include "test_point_cloud_callbacks.h"
 
+struct provizio_radar_point_protocol_v1
+{
+    float x_meters;                           // Forward, radar relative
+    float y_meters;                           // Left, radar relative
+    float z_meters;                           // Up, radar relative
+    float radar_relative_radial_velocity_m_s; // Forward, radar relative
+    float signal_to_noise_ratio;
+};
+
+struct provizio_radar_point_cloud_packet_v1
+{
+    provizio_radar_point_cloud_packet_header header;
+    struct provizio_radar_point_protocol_v1
+        radar_points[(PROVIZIO__MAX_PAYLOAD_PER_UDP_PACKET_BYTES - sizeof(provizio_radar_point_cloud_packet_header)) /
+                     sizeof(struct provizio_radar_point_protocol_v1)];
+};
+
 enum
 {
     test_message_length = 1024
@@ -58,10 +75,81 @@ void test_provizio_radar_point_cloud_callback(const provizio_radar_point_cloud *
     data->last_point_clouds[0] = *point_cloud;
 }
 
-static int32_t create_test_pointcloud_packet(provizio_radar_point_cloud_packet *packet, const uint16_t protocol_version,
-                                             const uint32_t frame_index, const uint64_t timestamp,
-                                             const uint16_t radar_position_id, const uint16_t radar_mode,
-                                             const uint16_t total_points_in_frame, const uint16_t num_points_in_packet)
+static int32_t create_test_pointcloud_packet(provizio_radar_point_cloud_packet *packet, const uint32_t frame_index,
+                                             const uint64_t timestamp, const uint16_t radar_position_id,
+                                             const uint16_t radar_mode, const uint16_t total_points_in_frame,
+                                             const uint16_t num_points_in_packet)
+{
+    const float x_meters_min = -100.0F;
+    const float x_meters_max = 100.0F;
+    const float x_meters_step = 12.33F;
+    const float y_meters_min = -15.0F;
+    const float y_meters_max = 15.0F;
+    const float y_meters_step = 1.17F;
+    const float z_meters_min = -2.0F;
+    const float z_meters_max = 25.0F;
+    const float z_meters_step = 0.47F;
+    const float relative_velocity_min = -30.0F;
+    const float relative_velocity_max = 30.0F;
+    const float relative_velocity_step = 5.31F;
+    const float ground_velocity_min = -3.0F;
+    const float ground_velocity_max = 13.0F;
+    const float ground_velocity_step = 3.14F;
+    const float signal_to_noise_ratio_min = 2.0F;
+    const float signal_to_noise_ratio_max = 50.0F;
+    const float signal_to_noise_ratio_step = 3.73F;
+    const float half = 0.5F;
+
+    float x_meters = (x_meters_min + x_meters_max) * half;
+    float y_meters = (y_meters_min + y_meters_max) * half;
+    float z_meters = (z_meters_min + z_meters_max) * half;
+    float relative_velocity = (relative_velocity_min + relative_velocity_max) * half;
+    float ground_velocity = (ground_velocity_min + ground_velocity_max) * half;
+    float signal_to_noise_ratio = (signal_to_noise_ratio_min + signal_to_noise_ratio_max) * half;
+
+    memset(packet, 0, sizeof(provizio_radar_point_cloud_packet));
+
+    provizio_set_protocol_field_uint16_t(&packet->header.protocol_header.packet_type,
+                                         PROVIZIO__RADAR_API_POINT_CLOUD_PACKET_TYPE);
+    provizio_set_protocol_field_uint16_t(&packet->header.protocol_header.protocol_version,
+                                         PROVIZIO__RADAR_API_POINT_CLOUD_PROTOCOL_VERSION);
+    provizio_set_protocol_field_uint32_t(&packet->header.frame_index, frame_index);
+    provizio_set_protocol_field_uint64_t(&packet->header.timestamp, timestamp);
+    provizio_set_protocol_field_uint16_t(&packet->header.radar_position_id, radar_position_id);
+    provizio_set_protocol_field_uint16_t(&packet->header.radar_mode, radar_mode);
+    provizio_set_protocol_field_uint16_t(&packet->header.total_points_in_frame, total_points_in_frame);
+    provizio_set_protocol_field_uint16_t(&packet->header.num_points_in_packet, num_points_in_packet);
+
+#pragma unroll(8)
+    for (uint16_t j = 0; j < num_points_in_packet; ++j) // NOLINT: The loop is just fine
+    {
+#define PROVIZIO__NEXT_TEST_VALUE(v) ((v##_min) + fmodf((v) + (v##_step) - (v##_min), (v##_max) - (v##_min)))
+        x_meters = PROVIZIO__NEXT_TEST_VALUE(x_meters);
+        y_meters = PROVIZIO__NEXT_TEST_VALUE(y_meters);
+        z_meters = PROVIZIO__NEXT_TEST_VALUE(z_meters);
+        relative_velocity = PROVIZIO__NEXT_TEST_VALUE(relative_velocity);
+        ground_velocity = PROVIZIO__NEXT_TEST_VALUE(ground_velocity);
+        signal_to_noise_ratio = PROVIZIO__NEXT_TEST_VALUE(signal_to_noise_ratio);
+#undef PROVIZIO__NEXT_TEST_VALUE
+
+        provizio_set_protocol_field_float(&packet->radar_points[j].x_meters, x_meters);
+        provizio_set_protocol_field_float(&packet->radar_points[j].y_meters, y_meters);
+        provizio_set_protocol_field_float(&packet->radar_points[j].z_meters, z_meters);
+        provizio_set_protocol_field_float(&packet->radar_points[j].radar_relative_radial_velocity_m_s,
+                                          relative_velocity);
+        provizio_set_protocol_field_float(&packet->radar_points[j].signal_to_noise_ratio, signal_to_noise_ratio);
+        provizio_set_protocol_field_float(&packet->radar_points[j].ground_relative_radial_velocity_m_s,
+                                          ground_velocity);
+    }
+
+    return 0;
+}
+
+static int32_t create_test_pointcloud_packet_v1(struct provizio_radar_point_cloud_packet_v1 *packet,
+                                                const uint32_t frame_index, const uint64_t timestamp,
+                                                const uint16_t radar_position_id, const uint16_t radar_mode,
+                                                const uint16_t total_points_in_frame,
+                                                const uint16_t num_points_in_packet)
 {
     const float x_meters_min = -100.0F;
     const float x_meters_max = 100.0F;
@@ -86,13 +174,11 @@ static int32_t create_test_pointcloud_packet(provizio_radar_point_cloud_packet *
     float velocity = (velocity_min + velocity_max) * half;
     float signal_to_noise_ratio = (signal_to_noise_ratio_min + signal_to_noise_ratio_max) * half;
 
-    provizio_radar_point_v1_protocol *v1_radar_points = (provizio_radar_point_v1_protocol *)packet->radar_points;
-
-    memset(packet, 0, sizeof(provizio_radar_point_cloud_packet));
+    memset(packet, 0, sizeof(struct provizio_radar_point_cloud_packet_v1));
 
     provizio_set_protocol_field_uint16_t(&packet->header.protocol_header.packet_type,
                                          PROVIZIO__RADAR_API_POINT_CLOUD_PACKET_TYPE);
-    provizio_set_protocol_field_uint16_t(&packet->header.protocol_header.protocol_version, protocol_version);
+    provizio_set_protocol_field_uint16_t(&packet->header.protocol_header.protocol_version, 1);
     provizio_set_protocol_field_uint32_t(&packet->header.frame_index, frame_index);
     provizio_set_protocol_field_uint64_t(&packet->header.timestamp, timestamp);
     provizio_set_protocol_field_uint16_t(&packet->header.radar_position_id, radar_position_id);
@@ -111,23 +197,11 @@ static int32_t create_test_pointcloud_packet(provizio_radar_point_cloud_packet *
         signal_to_noise_ratio = PROVIZIO__NEXT_TEST_VALUE(signal_to_noise_ratio);
 #undef PROVIZIO__NEXT_TEST_VALUE
 
-        if (protocol_version >= 2)
-        {
-            provizio_set_protocol_field_float(&packet->radar_points[j].x_meters, x_meters);
-            provizio_set_protocol_field_float(&packet->radar_points[j].y_meters, y_meters);
-            provizio_set_protocol_field_float(&packet->radar_points[j].z_meters, z_meters);
-            provizio_set_protocol_field_float(&packet->radar_points[j].radar_relative_radial_velocity_m_s, velocity);
-            provizio_set_protocol_field_float(&packet->radar_points[j].signal_to_noise_ratio, signal_to_noise_ratio);
-            provizio_set_protocol_field_float(&packet->radar_points[j].ground_relative_radial_velocity_m_s, -velocity);
-        }
-        else
-        {
-            provizio_set_protocol_field_float(&v1_radar_points[j].x_meters, x_meters);
-            provizio_set_protocol_field_float(&v1_radar_points[j].y_meters, y_meters);
-            provizio_set_protocol_field_float(&v1_radar_points[j].z_meters, z_meters);
-            provizio_set_protocol_field_float(&v1_radar_points[j].radar_relative_radial_velocity_m_s, velocity);
-            provizio_set_protocol_field_float(&v1_radar_points[j].signal_to_noise_ratio, signal_to_noise_ratio);
-        }
+        provizio_set_protocol_field_float(&packet->radar_points[j].x_meters, x_meters);
+        provizio_set_protocol_field_float(&packet->radar_points[j].y_meters, y_meters);
+        provizio_set_protocol_field_float(&packet->radar_points[j].z_meters, z_meters);
+        provizio_set_protocol_field_float(&packet->radar_points[j].radar_relative_radial_velocity_m_s, velocity);
+        provizio_set_protocol_field_float(&packet->radar_points[j].signal_to_noise_ratio, signal_to_noise_ratio);
     }
 
     return 0;
@@ -493,10 +567,8 @@ static void test_provizio_handle_possible_radars_point_cloud_packet_ground_veloc
         provizio_radar_point_cloud_packet packet;
         memset(&packet, 0, sizeof(packet));
 
-        // Test Point Cloud Packet UDP Protocol Version 2
-
         TEST_ASSERT_EQUAL_INT32(0, // NOLINT
-                                create_test_pointcloud_packet(&packet, 2, frame_index, timestamp, radar_position_ids[i],
+                                create_test_pointcloud_packet(&packet, frame_index, timestamp, radar_position_ids[i],
                                                               radar_modes[i], num_points, points_in_packet));
 
         TEST_ASSERT_EQUAL_INT32(
@@ -504,26 +576,52 @@ static void test_provizio_handle_possible_radars_point_cloud_packet_ground_veloc
             provizio_handle_possible_radars_point_cloud_packet(api_contexts, num_contexts, &packet,
                                                                provizio_radar_point_cloud_packet_size(&packet.header)));
 
-        for (uint16_t j = 0; j < points_in_packet; ++j)
-        {
-            TEST_ASSERT_EQUAL_FLOAT( // NOLINT
-                callback_data->last_point_clouds[0].radar_points[j].radar_relative_radial_velocity_m_s,
-                callback_data->last_point_clouds[0].radar_points[j].ground_relative_radial_velocity_m_s * -1);
-        }
+        TEST_ASSERT_EQUAL_FLOAT( // NOLINT
+            8.14, callback_data->last_point_clouds[0].radar_points[0].ground_relative_radial_velocity_m_s);
+    }
+
+    free(api_contexts);
+    free(callback_data);
+}
+
+static void test_provizio_handle_possible_radars_point_cloud_packet_v1(void)
+{
+    const uint32_t frame_index = 1000;
+    const uint64_t timestamp = 0x0123456789abcdef;
+    const uint16_t radar_position_ids[2] = {provizio_radar_position_rear_left, provizio_radar_position_rear_right};
+    const uint16_t radar_modes[2] = {provizio_radar_mode_long_range, provizio_radar_mode_medium_range};
+    const uint16_t points_in_packet = 72;
+    const uint16_t num_points = 72;
+
+    const size_t num_contexts = 2;
+    provizio_radar_point_cloud_api_context *api_contexts =
+        (provizio_radar_point_cloud_api_context *)malloc(sizeof(provizio_radar_point_cloud_api_context) * num_contexts);
+    TEST_ASSERT_NOT_EQUAL(NULL, api_contexts);
+
+    test_provizio_radar_point_cloud_callback_data *callback_data =
+        (test_provizio_radar_point_cloud_callback_data *)malloc(sizeof(test_provizio_radar_point_cloud_callback_data));
+    TEST_ASSERT_NOT_EQUAL(NULL, callback_data);
+    memset(callback_data, 0, sizeof(test_provizio_radar_point_cloud_callback_data));
+
+    provizio_radar_point_cloud_api_contexts_init(&test_provizio_radar_point_cloud_callback, callback_data, api_contexts,
+                                                 num_contexts);
+
+    for (size_t i = 0; i < num_contexts; ++i) // NOLINT: Don't unroll the loop
+    {
+        struct provizio_radar_point_cloud_packet_v1 packet;
+        memset(&packet, 0, sizeof(packet));
 
         // Test Point Cloud Packet UDP Protocol Version 1
 
         TEST_ASSERT_EQUAL_INT32(0, // NOLINT
-                                create_test_pointcloud_packet(&packet, 1, frame_index + 1, timestamp,
-                                                              radar_position_ids[i], radar_modes[i], num_points,
-                                                              points_in_packet));
+                                create_test_pointcloud_packet_v1(&packet, frame_index, timestamp, radar_position_ids[i],
+                                                                 radar_modes[i], num_points, points_in_packet));
 
-        TEST_ASSERT_EQUAL_INT32(
-            0, // NOLINT
-            provizio_handle_possible_radars_point_cloud_packet(api_contexts, num_contexts, &packet,
-                                                               provizio_radar_point_cloud_packet_size(&packet.header)));
+        TEST_ASSERT_EQUAL_INT32( // NOLINT
+            0, provizio_handle_possible_radars_point_cloud_packet(
+                   api_contexts, num_contexts, &packet, provizio_radar_point_cloud_packet_size(&packet.header)));
 
-        for (uint16_t j = 0; j < points_in_packet; ++j)
+        for (size_t j = 0; j < num_points; ++j)
         {
             TEST_ASSERT_EQUAL_FLOAT( // NOLINT
                 nanf(""), callback_data->last_point_clouds[0].radar_points[j].ground_relative_radial_velocity_m_s);
@@ -552,6 +650,7 @@ int provizio_run_test_radar_point_cloud(void)
     RUN_TEST(test_provizio_handle_possible_radar_point_cloud_packet_ok);
     RUN_TEST(test_provizio_handle_possible_radars_point_cloud_packet_ok);
     RUN_TEST(test_provizio_handle_possible_radars_point_cloud_packet_ground_velocity);
+    RUN_TEST(test_provizio_handle_possible_radars_point_cloud_packet_v1);
 
     return UNITY_END();
 }

--- a/test/c_99/src/test_radar_points_accumulation.c
+++ b/test/c_99/src/test_radar_points_accumulation.c
@@ -212,7 +212,7 @@ static void test_accumulate_radar_point_cloud_move(void)
     point_clouds[0].radar_points[0].x_meters = 1.0F;              // NOLINT: Fine in tests
     point_clouds[0].radar_points[0].y_meters = 2.0F;              // NOLINT: Fine in tests
     point_clouds[0].radar_points[0].z_meters = 3.0F;              // NOLINT: Fine in tests
-    point_clouds[0].radar_points[0].velocity_m_s = 4.0F;          // NOLINT: Fine in tests
+    point_clouds[0].radar_points[0].radar_relative_radial_velocity_m_s = 4.0F;          // NOLINT: Fine in tests
     point_clouds[0].radar_points[0].signal_to_noise_ratio = 5.0F; // NOLINT: Fine in tests
 
     // Point Cloud 1
@@ -221,12 +221,12 @@ static void test_accumulate_radar_point_cloud_move(void)
     point_clouds[1].radar_points[0].x_meters = 10.0F;               // NOLINT: Fine in tests
     point_clouds[1].radar_points[0].y_meters = 20.0F;               // NOLINT: Fine in tests
     point_clouds[1].radar_points[0].z_meters = 30.0F;               // NOLINT: Fine in tests
-    point_clouds[1].radar_points[0].velocity_m_s = 40.0F;           // NOLINT: Fine in tests
+    point_clouds[1].radar_points[0].radar_relative_radial_velocity_m_s = 40.0F;           // NOLINT: Fine in tests
     point_clouds[1].radar_points[0].signal_to_noise_ratio = 50.0F;  // NOLINT: Fine in tests
     point_clouds[1].radar_points[1].x_meters = 100.0F;              // NOLINT: Fine in tests
     point_clouds[1].radar_points[1].y_meters = 200.0F;              // NOLINT: Fine in tests
     point_clouds[1].radar_points[1].z_meters = 300.0F;              // NOLINT: Fine in tests
-    point_clouds[1].radar_points[1].velocity_m_s = 400.0F;          // NOLINT: Fine in tests
+    point_clouds[1].radar_points[1].radar_relative_radial_velocity_m_s = 400.0F;          // NOLINT: Fine in tests
     point_clouds[1].radar_points[1].signal_to_noise_ratio = 500.0F; // NOLINT: Fine in tests
 
     // Fix 0
@@ -373,8 +373,8 @@ static void test_accumulate_radar_point_cloud_move(void)
                                 fix_when_received[1].position.up_meters + fix_when_received[0].position.up_meters,
                             transformed_accumulated_point_cloud->radar_points[0].z_meters);
     // TODO(APT-746): Velocities need to be updated for accumulated points
-    TEST_ASSERT_EQUAL_FLOAT(point_clouds[0].radar_points[0].velocity_m_s, // NOLINT
-                            transformed_accumulated_point_cloud->radar_points[0].velocity_m_s);
+    TEST_ASSERT_EQUAL_FLOAT(point_clouds[0].radar_points[0].radar_relative_radial_velocity_m_s, // NOLINT
+                            transformed_accumulated_point_cloud->radar_points[0].radar_relative_radial_velocity_m_s);
     TEST_ASSERT_EQUAL_FLOAT(point_clouds[0].radar_points[0].signal_to_noise_ratio, // NOLINT
                             transformed_accumulated_point_cloud->radar_points[0].signal_to_noise_ratio);
 
@@ -395,8 +395,8 @@ static void test_accumulate_radar_point_cloud_move(void)
                                 fix_when_received[1].position.up_meters + fix_when_received[0].position.up_meters,
                             transformed_accumulated_point.z_meters);
     // TODO(APT-746): Velocities need to be updated for accumulated points
-    TEST_ASSERT_EQUAL_FLOAT(point_clouds[0].radar_points[0].velocity_m_s, // NOLINT
-                            transformed_accumulated_point.velocity_m_s);
+    TEST_ASSERT_EQUAL_FLOAT(point_clouds[0].radar_points[0].radar_relative_radial_velocity_m_s, // NOLINT
+                            transformed_accumulated_point.radar_relative_radial_velocity_m_s);
     TEST_ASSERT_EQUAL_FLOAT(point_clouds[0].radar_points[0].signal_to_noise_ratio, // NOLINT
                             transformed_accumulated_point.signal_to_noise_ratio);
 
@@ -521,7 +521,7 @@ static void test_accumulate_radar_point_cloud_rotation_yaw(void)
     point_clouds[0].radar_points[0].x_meters = 101.0F;                                         // NOLINT: fine in tests
     point_clouds[0].radar_points[0].y_meters = 102.0F;                                         // NOLINT: fine in tests
     point_clouds[0].radar_points[0].z_meters = 103.0F;                                         // NOLINT: fine in tests
-    point_clouds[0].radar_points[0].velocity_m_s = 5.0F;                                       // NOLINT: fine in tests
+    point_clouds[0].radar_points[0].radar_relative_radial_velocity_m_s = 5.0F;                                       // NOLINT: fine in tests
     point_clouds[0].radar_points[0].signal_to_noise_ratio = 5.0F;                              // NOLINT: fine in tests
     provizio_quaternion_set_euler_angles(0.0F, 0.0F, 0.0F, &fix_when_received[0].orientation); // NOLINT: fine in tests
 
@@ -531,7 +531,7 @@ static void test_accumulate_radar_point_cloud_rotation_yaw(void)
     point_clouds[1].radar_points[0].x_meters = 110.0F;                    // NOLINT: fine in tests
     point_clouds[1].radar_points[0].y_meters = 120.0F;                    // NOLINT: fine in tests
     point_clouds[1].radar_points[0].z_meters = 130.0F;                    // NOLINT: fine in tests
-    point_clouds[1].radar_points[0].velocity_m_s = 5.0F;                  // NOLINT: fine in tests
+    point_clouds[1].radar_points[0].radar_relative_radial_velocity_m_s = 5.0F;                  // NOLINT: fine in tests
     point_clouds[1].radar_points[0].signal_to_noise_ratio = 5.0F;         // NOLINT: fine in tests
     provizio_quaternion_set_euler_angles(0.0F, 0.0F, (float)(M_PI / 6.0), // NOLINT: fine in tests
                                          &fix_when_received[1].orientation);
@@ -542,7 +542,7 @@ static void test_accumulate_radar_point_cloud_rotation_yaw(void)
     point_clouds[2].radar_points[0].x_meters = 200.0F;                    // NOLINT: fine in tests
     point_clouds[2].radar_points[0].y_meters = 300.0F;                    // NOLINT: fine in tests
     point_clouds[2].radar_points[0].z_meters = 400.0F;                    // NOLINT: fine in tests
-    point_clouds[2].radar_points[0].velocity_m_s = 5.0F;                  // NOLINT: fine in tests
+    point_clouds[2].radar_points[0].radar_relative_radial_velocity_m_s = 5.0F;                  // NOLINT: fine in tests
     point_clouds[2].radar_points[0].signal_to_noise_ratio = 5.0F;         // NOLINT: fine in tests
     provizio_quaternion_set_euler_angles(0.0F, 0.0F, (float)(M_PI / 4.0), // NOLINT: fine in tests
                                          &fix_when_received[2].orientation);
@@ -642,7 +642,7 @@ static void test_accumulate_radar_point_cloud_rotation_pitch(void)
     point_clouds[0].radar_points[0].x_meters = 101.0F;            // NOLINT: fine in tests
     point_clouds[0].radar_points[0].y_meters = 102.0F;            // NOLINT: fine in tests
     point_clouds[0].radar_points[0].z_meters = 103.0F;            // NOLINT: fine in tests
-    point_clouds[0].radar_points[0].velocity_m_s = 5.0F;          // NOLINT: fine in tests
+    point_clouds[0].radar_points[0].radar_relative_radial_velocity_m_s = 5.0F;          // NOLINT: fine in tests
     point_clouds[0].radar_points[0].signal_to_noise_ratio = 5.0F; // NOLINT: fine in tests
     provizio_quaternion_set_euler_angles(0.0F, 0.0F, 0.0F, &fix_when_received[0].orientation);
 
@@ -652,7 +652,7 @@ static void test_accumulate_radar_point_cloud_rotation_pitch(void)
     point_clouds[1].radar_points[0].x_meters = 110.0F;                    // NOLINT: fine in tests
     point_clouds[1].radar_points[0].y_meters = 120.0F;                    // NOLINT: fine in tests
     point_clouds[1].radar_points[0].z_meters = 130.0F;                    // NOLINT: fine in tests
-    point_clouds[1].radar_points[0].velocity_m_s = 5.0F;                  // NOLINT: fine in tests
+    point_clouds[1].radar_points[0].radar_relative_radial_velocity_m_s = 5.0F;                  // NOLINT: fine in tests
     point_clouds[1].radar_points[0].signal_to_noise_ratio = 5.0F;         // NOLINT: fine in tests
     provizio_quaternion_set_euler_angles(0.0F, (float)(M_PI / 6.0), 0.0F, // NOLINT: fine in tests
                                          &fix_when_received[1].orientation);
@@ -663,7 +663,7 @@ static void test_accumulate_radar_point_cloud_rotation_pitch(void)
     point_clouds[2].radar_points[0].x_meters = 200.0F;                    // NOLINT: fine in tests
     point_clouds[2].radar_points[0].y_meters = 300.0F;                    // NOLINT: fine in tests
     point_clouds[2].radar_points[0].z_meters = 400.0F;                    // NOLINT: fine in tests
-    point_clouds[2].radar_points[0].velocity_m_s = 5.0F;                  // NOLINT: fine in tests
+    point_clouds[2].radar_points[0].radar_relative_radial_velocity_m_s = 5.0F;                  // NOLINT: fine in tests
     point_clouds[2].radar_points[0].signal_to_noise_ratio = 5.0F;         // NOLINT: fine in tests
     provizio_quaternion_set_euler_angles(0.0F, (float)(M_PI / 4.0), 0.0F, // NOLINT: fine in tests
                                          &fix_when_received[2].orientation);
@@ -763,7 +763,7 @@ static void test_accumulate_radar_point_cloud_rotation_roll(void)
     point_clouds[0].radar_points[0].x_meters = 101.0F;            // NOLINT: fine in tests
     point_clouds[0].radar_points[0].y_meters = 102.0F;            // NOLINT: fine in tests
     point_clouds[0].radar_points[0].z_meters = 103.0F;            // NOLINT: fine in tests
-    point_clouds[0].radar_points[0].velocity_m_s = 5.0F;          // NOLINT: fine in tests
+    point_clouds[0].radar_points[0].radar_relative_radial_velocity_m_s = 5.0F;          // NOLINT: fine in tests
     point_clouds[0].radar_points[0].signal_to_noise_ratio = 5.0F; // NOLINT: fine in tests
     provizio_quaternion_set_euler_angles(0.0F, 0.0F, 0.0F, &fix_when_received[0].orientation);
 
@@ -773,7 +773,7 @@ static void test_accumulate_radar_point_cloud_rotation_roll(void)
     point_clouds[1].radar_points[0].x_meters = 110.0F;                    // NOLINT: fine in tests
     point_clouds[1].radar_points[0].y_meters = 120.0F;                    // NOLINT: fine in tests
     point_clouds[1].radar_points[0].z_meters = 130.0F;                    // NOLINT: fine in tests
-    point_clouds[1].radar_points[0].velocity_m_s = 5.0F;                  // NOLINT: fine in tests
+    point_clouds[1].radar_points[0].radar_relative_radial_velocity_m_s = 5.0F;                  // NOLINT: fine in tests
     point_clouds[1].radar_points[0].signal_to_noise_ratio = 5.0F;         // NOLINT: fine in tests
     provizio_quaternion_set_euler_angles((float)(M_PI / 6.0), 0.0F, 0.0F, // NOLINT: fine in tests
                                          &fix_when_received[1].orientation);
@@ -784,7 +784,7 @@ static void test_accumulate_radar_point_cloud_rotation_roll(void)
     point_clouds[2].radar_points[0].x_meters = 200.0F;                    // NOLINT: fine in tests
     point_clouds[2].radar_points[0].y_meters = 300.0F;                    // NOLINT: fine in tests
     point_clouds[2].radar_points[0].z_meters = 400.0F;                    // NOLINT: fine in tests
-    point_clouds[2].radar_points[0].velocity_m_s = 5.0F;                  // NOLINT: fine in tests
+    point_clouds[2].radar_points[0].radar_relative_radial_velocity_m_s = 5.0F;                  // NOLINT: fine in tests
     point_clouds[2].radar_points[0].signal_to_noise_ratio = 5.0F;         // NOLINT: fine in tests
     provizio_quaternion_set_euler_angles((float)(M_PI / 4.0), 0.0F, 0.0F, // NOLINT: fine in tests
                                          &fix_when_received[2].orientation);
@@ -865,7 +865,7 @@ static void test_accumulate_radar_point_cloud_rotation_and_move_simple(void)
     point_cloud->radar_points[0].x_meters = 1.0F;               // NOLINT: magic numbers are fine in tests
     point_cloud->radar_points[0].y_meters = 2.0F;               // NOLINT: magic numbers are fine in tests
     point_cloud->radar_points[0].z_meters = 3.0F;               // NOLINT: magic numbers are fine in tests
-    point_cloud->radar_points[0].velocity_m_s = 10.0F;          // NOLINT: magic numbers are fine in tests
+    point_cloud->radar_points[0].radar_relative_radial_velocity_m_s = 10.0F;          // NOLINT: magic numbers are fine in tests
     point_cloud->radar_points[0].signal_to_noise_ratio = 10.0F; // NOLINT: magic numbers are fine in tests
 
     provizio_enu_fix fix_when_received;
@@ -936,7 +936,7 @@ static void test_accumulate_radar_point_cloud_rotation_and_move(void)
     point_clouds[0].radar_points[0].x_meters = 101.0F;            // NOLINT: magic numbers are fine in tests
     point_clouds[0].radar_points[0].y_meters = 102.0F;            // NOLINT: magic numbers are fine in tests
     point_clouds[0].radar_points[0].z_meters = 103.0F;            // NOLINT: magic numbers are fine in tests
-    point_clouds[0].radar_points[0].velocity_m_s = 5.0F;          // NOLINT: magic numbers are fine in tests
+    point_clouds[0].radar_points[0].radar_relative_radial_velocity_m_s = 5.0F;          // NOLINT: magic numbers are fine in tests
     point_clouds[0].radar_points[0].signal_to_noise_ratio = 5.0F; // NOLINT: magic numbers are fine in tests
     fix_when_received[0].position.east_meters = 879.020F;         // NOLINT: magic numbers are fine in tests
     fix_when_received[0].position.north_meters = 529.971F;        // NOLINT: magic numbers are fine in tests
@@ -948,7 +948,7 @@ static void test_accumulate_radar_point_cloud_rotation_and_move(void)
     point_clouds[1].radar_points[0].x_meters = 110.0F;            // NOLINT: magic numbers are fine in tests
     point_clouds[1].radar_points[0].y_meters = 120.0F;            // NOLINT: magic numbers are fine in tests
     point_clouds[1].radar_points[0].z_meters = 130.0F;            // NOLINT: magic numbers are fine in tests
-    point_clouds[1].radar_points[0].velocity_m_s = 5.0F;          // NOLINT: magic numbers are fine in tests
+    point_clouds[1].radar_points[0].radar_relative_radial_velocity_m_s = 5.0F;          // NOLINT: magic numbers are fine in tests
     point_clouds[1].radar_points[0].signal_to_noise_ratio = 5.0F; // NOLINT: magic numbers are fine in tests
     fix_when_received[1].position.east_meters = 871.156F;         // NOLINT: magic numbers are fine in tests
     fix_when_received[1].position.north_meters = 548.981F;        // NOLINT: magic numbers are fine in tests
@@ -960,7 +960,7 @@ static void test_accumulate_radar_point_cloud_rotation_and_move(void)
     point_clouds[2].radar_points[0].x_meters = 200.0F;                    // NOLINT: magic numbers are fine in tests
     point_clouds[2].radar_points[0].y_meters = 300.0F;                    // NOLINT: magic numbers are fine in tests
     point_clouds[2].radar_points[0].z_meters = 400.0F;                    // NOLINT: magic numbers are fine in tests
-    point_clouds[2].radar_points[0].velocity_m_s = 5.0F;                  // NOLINT: magic numbers are fine in tests
+    point_clouds[2].radar_points[0].radar_relative_radial_velocity_m_s = 5.0F;                  // NOLINT: magic numbers are fine in tests
     point_clouds[2].radar_points[0].signal_to_noise_ratio = 5.0F;         // NOLINT: magic numbers are fine in tests
     fix_when_received[2].position.east_meters = 899.447F;                 // NOLINT: magic numbers are fine in tests
     fix_when_received[2].position.north_meters = 562.369F;                // NOLINT: magic numbers are fine in tests
@@ -1149,13 +1149,13 @@ static void test_provizio_accumulate_radar_point_cloud_static(void)
     point_cloud->radar_points[0].y_meters = 0.0F;
     point_cloud->radar_points[0].signal_to_noise_ratio = default_signal_to_noise_ratio;
     // Ground-relative velocity is 0 m/s
-    point_cloud->radar_points[0].velocity_m_s = -ego_velocity_m_s + 0.0F;
+    point_cloud->radar_points[0].radar_relative_radial_velocity_m_s = -ego_velocity_m_s + 0.0F;
     // All 3 times, there is a dynamic point at EgoRelative(0, 1)
     point_cloud->radar_points[1].x_meters = 0.0F;
     point_cloud->radar_points[1].y_meters = 1.0F;
     point_cloud->radar_points[1].signal_to_noise_ratio = default_signal_to_noise_ratio;
     // Ground-relative velocity is 10 m/s
-    point_cloud->radar_points[1].velocity_m_s = -ego_velocity_m_s + 10.0F; // NOLINT: fine in test
+    point_cloud->radar_points[1].radar_relative_radial_velocity_m_s = -ego_velocity_m_s + 10.0F; // NOLINT: fine in test
 
     // 1st reading: ENU(1, 1, 0), heading = 0, static point at ENU(2, 1, 0), moving point at ENU(1, 2, 0)
     fix_when_received.position.east_meters = fix_when_received.position.north_meters = 1.0F;
@@ -1175,7 +1175,7 @@ static void test_provizio_accumulate_radar_point_cloud_static(void)
     TEST_ASSERT_FLOAT_WITHIN(epsilon, 1.0F, transformed_point.x_meters);
     TEST_ASSERT_FLOAT_WITHIN(epsilon, 0.0F, transformed_point.y_meters);
     TEST_ASSERT_FLOAT_WITHIN(epsilon, 0.0F, transformed_point.z_meters);
-    TEST_ASSERT_FLOAT_WITHIN(epsilon, -ego_velocity_m_s + 0.0F, transformed_point.velocity_m_s);
+    TEST_ASSERT_FLOAT_WITHIN(epsilon, -ego_velocity_m_s + 0.0F, transformed_point.radar_relative_radial_velocity_m_s);
     TEST_ASSERT_FLOAT_WITHIN(epsilon, default_signal_to_noise_ratio, transformed_point.signal_to_noise_ratio);
     provizio_accumulated_radar_point_cloud_iterator_next_point(&iterator, accumulated_point_clouds,
                                                                num_accumulated_clouds);
@@ -1201,7 +1201,7 @@ static void test_provizio_accumulate_radar_point_cloud_static(void)
     TEST_ASSERT_FLOAT_WITHIN(epsilon, 1.0F, transformed_point.x_meters);
     TEST_ASSERT_FLOAT_WITHIN(epsilon, 0.0F, transformed_point.y_meters);
     TEST_ASSERT_FLOAT_WITHIN(epsilon, 0.0F, transformed_point.z_meters);
-    TEST_ASSERT_FLOAT_WITHIN(epsilon, -ego_velocity_m_s + 0.0F, transformed_point.velocity_m_s);
+    TEST_ASSERT_FLOAT_WITHIN(epsilon, -ego_velocity_m_s + 0.0F, transformed_point.radar_relative_radial_velocity_m_s);
     TEST_ASSERT_FLOAT_WITHIN(epsilon, default_signal_to_noise_ratio, transformed_point.signal_to_noise_ratio);
     provizio_accumulated_radar_point_cloud_iterator_next_point(&iterator, accumulated_point_clouds,
                                                                num_accumulated_clouds);
@@ -1212,7 +1212,7 @@ static void test_provizio_accumulate_radar_point_cloud_static(void)
     TEST_ASSERT_FLOAT_WITHIN(epsilon, -1.0F, transformed_point.x_meters);
     TEST_ASSERT_FLOAT_WITHIN(epsilon, 0.0F, transformed_point.y_meters);
     TEST_ASSERT_FLOAT_WITHIN(epsilon, 0.0F, transformed_point.z_meters);
-    TEST_ASSERT_FLOAT_WITHIN(epsilon, -ego_velocity_m_s + 0.0F, transformed_point.velocity_m_s);
+    TEST_ASSERT_FLOAT_WITHIN(epsilon, -ego_velocity_m_s + 0.0F, transformed_point.radar_relative_radial_velocity_m_s);
     TEST_ASSERT_FLOAT_WITHIN(epsilon, default_signal_to_noise_ratio, transformed_point.signal_to_noise_ratio);
     provizio_accumulated_radar_point_cloud_iterator_next_point(&iterator, accumulated_point_clouds,
                                                                num_accumulated_clouds);
@@ -1238,7 +1238,7 @@ static void test_provizio_accumulate_radar_point_cloud_static(void)
     TEST_ASSERT_FLOAT_WITHIN(epsilon, 1.0F, transformed_point.x_meters);
     TEST_ASSERT_FLOAT_WITHIN(epsilon, 0.0F, transformed_point.y_meters);
     TEST_ASSERT_FLOAT_WITHIN(epsilon, 0.0F, transformed_point.z_meters);
-    TEST_ASSERT_FLOAT_WITHIN(epsilon, -ego_velocity_m_s + 0.0F, transformed_point.velocity_m_s);
+    TEST_ASSERT_FLOAT_WITHIN(epsilon, -ego_velocity_m_s + 0.0F, transformed_point.radar_relative_radial_velocity_m_s);
     TEST_ASSERT_FLOAT_WITHIN(epsilon, default_signal_to_noise_ratio, transformed_point.signal_to_noise_ratio);
     provizio_accumulated_radar_point_cloud_iterator_next_point(&iterator, accumulated_point_clouds,
                                                                num_accumulated_clouds);
@@ -1249,7 +1249,7 @@ static void test_provizio_accumulate_radar_point_cloud_static(void)
     TEST_ASSERT_FLOAT_WITHIN(epsilon, 1.0F, transformed_point.x_meters);
     TEST_ASSERT_FLOAT_WITHIN(epsilon, 0.0F, transformed_point.y_meters);
     TEST_ASSERT_FLOAT_WITHIN(epsilon, 0.0F, transformed_point.z_meters);
-    TEST_ASSERT_FLOAT_WITHIN(epsilon, -ego_velocity_m_s + 0.0F, transformed_point.velocity_m_s);
+    TEST_ASSERT_FLOAT_WITHIN(epsilon, -ego_velocity_m_s + 0.0F, transformed_point.radar_relative_radial_velocity_m_s);
     TEST_ASSERT_FLOAT_WITHIN(epsilon, default_signal_to_noise_ratio, transformed_point.signal_to_noise_ratio);
     provizio_accumulated_radar_point_cloud_iterator_next_point(&iterator, accumulated_point_clouds,
                                                                num_accumulated_clouds);
@@ -1260,7 +1260,7 @@ static void test_provizio_accumulate_radar_point_cloud_static(void)
     TEST_ASSERT_FLOAT_WITHIN(epsilon, 1.0F, transformed_point.x_meters); // NOLINT
     TEST_ASSERT_FLOAT_WITHIN(epsilon, 2.0F, transformed_point.y_meters); // NOLINT
     TEST_ASSERT_FLOAT_WITHIN(epsilon, 0.0F, transformed_point.z_meters); // NOLINT
-    TEST_ASSERT_FLOAT_WITHIN(epsilon, -ego_velocity_m_s + 0.0F, transformed_point.velocity_m_s);
+    TEST_ASSERT_FLOAT_WITHIN(epsilon, -ego_velocity_m_s + 0.0F, transformed_point.radar_relative_radial_velocity_m_s);
     TEST_ASSERT_FLOAT_WITHIN(epsilon, default_signal_to_noise_ratio, transformed_point.signal_to_noise_ratio);
     provizio_accumulated_radar_point_cloud_iterator_next_point(&iterator, accumulated_point_clouds,
                                                                num_accumulated_clouds);
@@ -1424,7 +1424,7 @@ static void test_provizio_accumulated_radar_point_cloud_iterator_get_point_end(v
     TEST_ASSERT_EQUAL_FLOAT(0, transformed_point.x_meters);              // NOLINT
     TEST_ASSERT_EQUAL_FLOAT(0, transformed_point.y_meters);              // NOLINT
     TEST_ASSERT_EQUAL_FLOAT(0, transformed_point.z_meters);              // NOLINT
-    TEST_ASSERT_EQUAL_FLOAT(0, transformed_point.velocity_m_s);          // NOLINT
+    TEST_ASSERT_EQUAL_FLOAT(0, transformed_point.radar_relative_radial_velocity_m_s);          // NOLINT
     TEST_ASSERT_EQUAL_FLOAT(0, transformed_point.signal_to_noise_ratio); // NOLINT
     TEST_ASSERT_TRUE(                                                    // It checks it's all zeroes now
         *((uint8_t *)transformation_matrix) == 0 &&

--- a/test/c_99/src/test_radar_points_accumulation.c
+++ b/test/c_99/src/test_radar_points_accumulation.c
@@ -209,25 +209,25 @@ static void test_accumulate_radar_point_cloud_move(void)
     // Point Cloud 0
     point_clouds[0].frame_index = 0;
     point_clouds[0].num_points_expected = point_clouds[0].num_points_received = 1;
-    point_clouds[0].radar_points[0].x_meters = 1.0F;              // NOLINT: Fine in tests
-    point_clouds[0].radar_points[0].y_meters = 2.0F;              // NOLINT: Fine in tests
-    point_clouds[0].radar_points[0].z_meters = 3.0F;              // NOLINT: Fine in tests
-    point_clouds[0].radar_points[0].radar_relative_radial_velocity_m_s = 4.0F;          // NOLINT: Fine in tests
-    point_clouds[0].radar_points[0].signal_to_noise_ratio = 5.0F; // NOLINT: Fine in tests
+    point_clouds[0].radar_points[0].x_meters = 1.0F;                           // NOLINT: Fine in tests
+    point_clouds[0].radar_points[0].y_meters = 2.0F;                           // NOLINT: Fine in tests
+    point_clouds[0].radar_points[0].z_meters = 3.0F;                           // NOLINT: Fine in tests
+    point_clouds[0].radar_points[0].radar_relative_radial_velocity_m_s = 4.0F; // NOLINT: Fine in tests
+    point_clouds[0].radar_points[0].signal_to_noise_ratio = 5.0F;              // NOLINT: Fine in tests
 
     // Point Cloud 1
     point_clouds[1].frame_index = 2;
     point_clouds[1].num_points_expected = point_clouds[1].num_points_received = 2;
-    point_clouds[1].radar_points[0].x_meters = 10.0F;               // NOLINT: Fine in tests
-    point_clouds[1].radar_points[0].y_meters = 20.0F;               // NOLINT: Fine in tests
-    point_clouds[1].radar_points[0].z_meters = 30.0F;               // NOLINT: Fine in tests
-    point_clouds[1].radar_points[0].radar_relative_radial_velocity_m_s = 40.0F;           // NOLINT: Fine in tests
-    point_clouds[1].radar_points[0].signal_to_noise_ratio = 50.0F;  // NOLINT: Fine in tests
-    point_clouds[1].radar_points[1].x_meters = 100.0F;              // NOLINT: Fine in tests
-    point_clouds[1].radar_points[1].y_meters = 200.0F;              // NOLINT: Fine in tests
-    point_clouds[1].radar_points[1].z_meters = 300.0F;              // NOLINT: Fine in tests
-    point_clouds[1].radar_points[1].radar_relative_radial_velocity_m_s = 400.0F;          // NOLINT: Fine in tests
-    point_clouds[1].radar_points[1].signal_to_noise_ratio = 500.0F; // NOLINT: Fine in tests
+    point_clouds[1].radar_points[0].x_meters = 10.0F;                            // NOLINT: Fine in tests
+    point_clouds[1].radar_points[0].y_meters = 20.0F;                            // NOLINT: Fine in tests
+    point_clouds[1].radar_points[0].z_meters = 30.0F;                            // NOLINT: Fine in tests
+    point_clouds[1].radar_points[0].radar_relative_radial_velocity_m_s = 40.0F;  // NOLINT: Fine in tests
+    point_clouds[1].radar_points[0].signal_to_noise_ratio = 50.0F;               // NOLINT: Fine in tests
+    point_clouds[1].radar_points[1].x_meters = 100.0F;                           // NOLINT: Fine in tests
+    point_clouds[1].radar_points[1].y_meters = 200.0F;                           // NOLINT: Fine in tests
+    point_clouds[1].radar_points[1].z_meters = 300.0F;                           // NOLINT: Fine in tests
+    point_clouds[1].radar_points[1].radar_relative_radial_velocity_m_s = 400.0F; // NOLINT: Fine in tests
+    point_clouds[1].radar_points[1].signal_to_noise_ratio = 500.0F;              // NOLINT: Fine in tests
 
     // Fix 0
     fix_when_received[0].position.east_meters = 1.0F;  // NOLINT: Fine in tests
@@ -521,30 +521,30 @@ static void test_accumulate_radar_point_cloud_rotation_yaw(void)
     point_clouds[0].radar_points[0].x_meters = 101.0F;                                         // NOLINT: fine in tests
     point_clouds[0].radar_points[0].y_meters = 102.0F;                                         // NOLINT: fine in tests
     point_clouds[0].radar_points[0].z_meters = 103.0F;                                         // NOLINT: fine in tests
-    point_clouds[0].radar_points[0].radar_relative_radial_velocity_m_s = 5.0F;                                       // NOLINT: fine in tests
+    point_clouds[0].radar_points[0].radar_relative_radial_velocity_m_s = 5.0F;                 // NOLINT: fine in tests
     point_clouds[0].radar_points[0].signal_to_noise_ratio = 5.0F;                              // NOLINT: fine in tests
     provizio_quaternion_set_euler_angles(0.0F, 0.0F, 0.0F, &fix_when_received[0].orientation); // NOLINT: fine in tests
 
     // Point Cloud 1
     point_clouds[1].frame_index = 1;
     point_clouds[1].num_points_expected = point_clouds[1].num_points_received = 1;
-    point_clouds[1].radar_points[0].x_meters = 110.0F;                    // NOLINT: fine in tests
-    point_clouds[1].radar_points[0].y_meters = 120.0F;                    // NOLINT: fine in tests
-    point_clouds[1].radar_points[0].z_meters = 130.0F;                    // NOLINT: fine in tests
-    point_clouds[1].radar_points[0].radar_relative_radial_velocity_m_s = 5.0F;                  // NOLINT: fine in tests
-    point_clouds[1].radar_points[0].signal_to_noise_ratio = 5.0F;         // NOLINT: fine in tests
-    provizio_quaternion_set_euler_angles(0.0F, 0.0F, (float)(M_PI / 6.0), // NOLINT: fine in tests
+    point_clouds[1].radar_points[0].x_meters = 110.0F;                         // NOLINT: fine in tests
+    point_clouds[1].radar_points[0].y_meters = 120.0F;                         // NOLINT: fine in tests
+    point_clouds[1].radar_points[0].z_meters = 130.0F;                         // NOLINT: fine in tests
+    point_clouds[1].radar_points[0].radar_relative_radial_velocity_m_s = 5.0F; // NOLINT: fine in tests
+    point_clouds[1].radar_points[0].signal_to_noise_ratio = 5.0F;              // NOLINT: fine in tests
+    provizio_quaternion_set_euler_angles(0.0F, 0.0F, (float)(M_PI / 6.0),      // NOLINT: fine in tests
                                          &fix_when_received[1].orientation);
 
     // Point Cloud 2
     point_clouds[2].frame_index = 2;
     point_clouds[2].num_points_expected = point_clouds[2].num_points_received = 1;
-    point_clouds[2].radar_points[0].x_meters = 200.0F;                    // NOLINT: fine in tests
-    point_clouds[2].radar_points[0].y_meters = 300.0F;                    // NOLINT: fine in tests
-    point_clouds[2].radar_points[0].z_meters = 400.0F;                    // NOLINT: fine in tests
-    point_clouds[2].radar_points[0].radar_relative_radial_velocity_m_s = 5.0F;                  // NOLINT: fine in tests
-    point_clouds[2].radar_points[0].signal_to_noise_ratio = 5.0F;         // NOLINT: fine in tests
-    provizio_quaternion_set_euler_angles(0.0F, 0.0F, (float)(M_PI / 4.0), // NOLINT: fine in tests
+    point_clouds[2].radar_points[0].x_meters = 200.0F;                         // NOLINT: fine in tests
+    point_clouds[2].radar_points[0].y_meters = 300.0F;                         // NOLINT: fine in tests
+    point_clouds[2].radar_points[0].z_meters = 400.0F;                         // NOLINT: fine in tests
+    point_clouds[2].radar_points[0].radar_relative_radial_velocity_m_s = 5.0F; // NOLINT: fine in tests
+    point_clouds[2].radar_points[0].signal_to_noise_ratio = 5.0F;              // NOLINT: fine in tests
+    provizio_quaternion_set_euler_angles(0.0F, 0.0F, (float)(M_PI / 4.0),      // NOLINT: fine in tests
                                          &fix_when_received[2].orientation);
 
     // Accumulate and check: iteration 0
@@ -639,33 +639,33 @@ static void test_accumulate_radar_point_cloud_rotation_pitch(void)
     // Point Cloud 0
     point_clouds[0].frame_index = 0;
     point_clouds[0].num_points_expected = point_clouds[0].num_points_received = 1;
-    point_clouds[0].radar_points[0].x_meters = 101.0F;            // NOLINT: fine in tests
-    point_clouds[0].radar_points[0].y_meters = 102.0F;            // NOLINT: fine in tests
-    point_clouds[0].radar_points[0].z_meters = 103.0F;            // NOLINT: fine in tests
-    point_clouds[0].radar_points[0].radar_relative_radial_velocity_m_s = 5.0F;          // NOLINT: fine in tests
-    point_clouds[0].radar_points[0].signal_to_noise_ratio = 5.0F; // NOLINT: fine in tests
+    point_clouds[0].radar_points[0].x_meters = 101.0F;                         // NOLINT: fine in tests
+    point_clouds[0].radar_points[0].y_meters = 102.0F;                         // NOLINT: fine in tests
+    point_clouds[0].radar_points[0].z_meters = 103.0F;                         // NOLINT: fine in tests
+    point_clouds[0].radar_points[0].radar_relative_radial_velocity_m_s = 5.0F; // NOLINT: fine in tests
+    point_clouds[0].radar_points[0].signal_to_noise_ratio = 5.0F;              // NOLINT: fine in tests
     provizio_quaternion_set_euler_angles(0.0F, 0.0F, 0.0F, &fix_when_received[0].orientation);
 
     // Point Cloud 1
     point_clouds[1].frame_index = 1;
     point_clouds[1].num_points_expected = point_clouds[1].num_points_received = 1;
-    point_clouds[1].radar_points[0].x_meters = 110.0F;                    // NOLINT: fine in tests
-    point_clouds[1].radar_points[0].y_meters = 120.0F;                    // NOLINT: fine in tests
-    point_clouds[1].radar_points[0].z_meters = 130.0F;                    // NOLINT: fine in tests
-    point_clouds[1].radar_points[0].radar_relative_radial_velocity_m_s = 5.0F;                  // NOLINT: fine in tests
-    point_clouds[1].radar_points[0].signal_to_noise_ratio = 5.0F;         // NOLINT: fine in tests
-    provizio_quaternion_set_euler_angles(0.0F, (float)(M_PI / 6.0), 0.0F, // NOLINT: fine in tests
+    point_clouds[1].radar_points[0].x_meters = 110.0F;                         // NOLINT: fine in tests
+    point_clouds[1].radar_points[0].y_meters = 120.0F;                         // NOLINT: fine in tests
+    point_clouds[1].radar_points[0].z_meters = 130.0F;                         // NOLINT: fine in tests
+    point_clouds[1].radar_points[0].radar_relative_radial_velocity_m_s = 5.0F; // NOLINT: fine in tests
+    point_clouds[1].radar_points[0].signal_to_noise_ratio = 5.0F;              // NOLINT: fine in tests
+    provizio_quaternion_set_euler_angles(0.0F, (float)(M_PI / 6.0), 0.0F,      // NOLINT: fine in tests
                                          &fix_when_received[1].orientation);
 
     // Point Cloud 2
     point_clouds[2].frame_index = 2;
     point_clouds[2].num_points_expected = point_clouds[2].num_points_received = 1;
-    point_clouds[2].radar_points[0].x_meters = 200.0F;                    // NOLINT: fine in tests
-    point_clouds[2].radar_points[0].y_meters = 300.0F;                    // NOLINT: fine in tests
-    point_clouds[2].radar_points[0].z_meters = 400.0F;                    // NOLINT: fine in tests
-    point_clouds[2].radar_points[0].radar_relative_radial_velocity_m_s = 5.0F;                  // NOLINT: fine in tests
-    point_clouds[2].radar_points[0].signal_to_noise_ratio = 5.0F;         // NOLINT: fine in tests
-    provizio_quaternion_set_euler_angles(0.0F, (float)(M_PI / 4.0), 0.0F, // NOLINT: fine in tests
+    point_clouds[2].radar_points[0].x_meters = 200.0F;                         // NOLINT: fine in tests
+    point_clouds[2].radar_points[0].y_meters = 300.0F;                         // NOLINT: fine in tests
+    point_clouds[2].radar_points[0].z_meters = 400.0F;                         // NOLINT: fine in tests
+    point_clouds[2].radar_points[0].radar_relative_radial_velocity_m_s = 5.0F; // NOLINT: fine in tests
+    point_clouds[2].radar_points[0].signal_to_noise_ratio = 5.0F;              // NOLINT: fine in tests
+    provizio_quaternion_set_euler_angles(0.0F, (float)(M_PI / 4.0), 0.0F,      // NOLINT: fine in tests
                                          &fix_when_received[2].orientation);
 
     // Accumulate and check: iteration 0
@@ -760,33 +760,33 @@ static void test_accumulate_radar_point_cloud_rotation_roll(void)
     // Point Cloud 0
     point_clouds[0].frame_index = 0;
     point_clouds[0].num_points_expected = point_clouds[0].num_points_received = 1;
-    point_clouds[0].radar_points[0].x_meters = 101.0F;            // NOLINT: fine in tests
-    point_clouds[0].radar_points[0].y_meters = 102.0F;            // NOLINT: fine in tests
-    point_clouds[0].radar_points[0].z_meters = 103.0F;            // NOLINT: fine in tests
-    point_clouds[0].radar_points[0].radar_relative_radial_velocity_m_s = 5.0F;          // NOLINT: fine in tests
-    point_clouds[0].radar_points[0].signal_to_noise_ratio = 5.0F; // NOLINT: fine in tests
+    point_clouds[0].radar_points[0].x_meters = 101.0F;                         // NOLINT: fine in tests
+    point_clouds[0].radar_points[0].y_meters = 102.0F;                         // NOLINT: fine in tests
+    point_clouds[0].radar_points[0].z_meters = 103.0F;                         // NOLINT: fine in tests
+    point_clouds[0].radar_points[0].radar_relative_radial_velocity_m_s = 5.0F; // NOLINT: fine in tests
+    point_clouds[0].radar_points[0].signal_to_noise_ratio = 5.0F;              // NOLINT: fine in tests
     provizio_quaternion_set_euler_angles(0.0F, 0.0F, 0.0F, &fix_when_received[0].orientation);
 
     // Point Cloud 1
     point_clouds[1].frame_index = 1;
     point_clouds[1].num_points_expected = point_clouds[1].num_points_received = 1;
-    point_clouds[1].radar_points[0].x_meters = 110.0F;                    // NOLINT: fine in tests
-    point_clouds[1].radar_points[0].y_meters = 120.0F;                    // NOLINT: fine in tests
-    point_clouds[1].radar_points[0].z_meters = 130.0F;                    // NOLINT: fine in tests
-    point_clouds[1].radar_points[0].radar_relative_radial_velocity_m_s = 5.0F;                  // NOLINT: fine in tests
-    point_clouds[1].radar_points[0].signal_to_noise_ratio = 5.0F;         // NOLINT: fine in tests
-    provizio_quaternion_set_euler_angles((float)(M_PI / 6.0), 0.0F, 0.0F, // NOLINT: fine in tests
+    point_clouds[1].radar_points[0].x_meters = 110.0F;                         // NOLINT: fine in tests
+    point_clouds[1].radar_points[0].y_meters = 120.0F;                         // NOLINT: fine in tests
+    point_clouds[1].radar_points[0].z_meters = 130.0F;                         // NOLINT: fine in tests
+    point_clouds[1].radar_points[0].radar_relative_radial_velocity_m_s = 5.0F; // NOLINT: fine in tests
+    point_clouds[1].radar_points[0].signal_to_noise_ratio = 5.0F;              // NOLINT: fine in tests
+    provizio_quaternion_set_euler_angles((float)(M_PI / 6.0), 0.0F, 0.0F,      // NOLINT: fine in tests
                                          &fix_when_received[1].orientation);
 
     // Point Cloud 2
     point_clouds[2].frame_index = 2;
     point_clouds[2].num_points_expected = point_clouds[2].num_points_received = 1;
-    point_clouds[2].radar_points[0].x_meters = 200.0F;                    // NOLINT: fine in tests
-    point_clouds[2].radar_points[0].y_meters = 300.0F;                    // NOLINT: fine in tests
-    point_clouds[2].radar_points[0].z_meters = 400.0F;                    // NOLINT: fine in tests
-    point_clouds[2].radar_points[0].radar_relative_radial_velocity_m_s = 5.0F;                  // NOLINT: fine in tests
-    point_clouds[2].radar_points[0].signal_to_noise_ratio = 5.0F;         // NOLINT: fine in tests
-    provizio_quaternion_set_euler_angles((float)(M_PI / 4.0), 0.0F, 0.0F, // NOLINT: fine in tests
+    point_clouds[2].radar_points[0].x_meters = 200.0F;                         // NOLINT: fine in tests
+    point_clouds[2].radar_points[0].y_meters = 300.0F;                         // NOLINT: fine in tests
+    point_clouds[2].radar_points[0].z_meters = 400.0F;                         // NOLINT: fine in tests
+    point_clouds[2].radar_points[0].radar_relative_radial_velocity_m_s = 5.0F; // NOLINT: fine in tests
+    point_clouds[2].radar_points[0].signal_to_noise_ratio = 5.0F;              // NOLINT: fine in tests
+    provizio_quaternion_set_euler_angles((float)(M_PI / 4.0), 0.0F, 0.0F,      // NOLINT: fine in tests
                                          &fix_when_received[2].orientation);
 
     // Accumulate and check: iteration 0
@@ -862,11 +862,11 @@ static void test_accumulate_radar_point_cloud_rotation_and_move_simple(void)
     memset(point_cloud, 0, sizeof(provizio_radar_point_cloud));
 
     point_cloud->num_points_expected = point_cloud->num_points_received = 1;
-    point_cloud->radar_points[0].x_meters = 1.0F;               // NOLINT: magic numbers are fine in tests
-    point_cloud->radar_points[0].y_meters = 2.0F;               // NOLINT: magic numbers are fine in tests
-    point_cloud->radar_points[0].z_meters = 3.0F;               // NOLINT: magic numbers are fine in tests
-    point_cloud->radar_points[0].radar_relative_radial_velocity_m_s = 10.0F;          // NOLINT: magic numbers are fine in tests
-    point_cloud->radar_points[0].signal_to_noise_ratio = 10.0F; // NOLINT: magic numbers are fine in tests
+    point_cloud->radar_points[0].x_meters = 1.0F;                            // NOLINT: magic numbers are fine in tests
+    point_cloud->radar_points[0].y_meters = 2.0F;                            // NOLINT: magic numbers are fine in tests
+    point_cloud->radar_points[0].z_meters = 3.0F;                            // NOLINT: magic numbers are fine in tests
+    point_cloud->radar_points[0].radar_relative_radial_velocity_m_s = 10.0F; // NOLINT: magic numbers are fine in tests
+    point_cloud->radar_points[0].signal_to_noise_ratio = 10.0F;              // NOLINT: magic numbers are fine in tests
 
     provizio_enu_fix fix_when_received;
     fix_when_received.position.east_meters = 10.0F;  // NOLINT: magic numbers are fine in tests
@@ -933,10 +933,11 @@ static void test_accumulate_radar_point_cloud_rotation_and_move(void)
     // Point Cloud 0
     point_clouds[0].frame_index = 0;
     point_clouds[0].num_points_expected = point_clouds[0].num_points_received = 1;
-    point_clouds[0].radar_points[0].x_meters = 101.0F;            // NOLINT: magic numbers are fine in tests
-    point_clouds[0].radar_points[0].y_meters = 102.0F;            // NOLINT: magic numbers are fine in tests
-    point_clouds[0].radar_points[0].z_meters = 103.0F;            // NOLINT: magic numbers are fine in tests
-    point_clouds[0].radar_points[0].radar_relative_radial_velocity_m_s = 5.0F;          // NOLINT: magic numbers are fine in tests
+    point_clouds[0].radar_points[0].x_meters = 101.0F; // NOLINT: magic numbers are fine in tests
+    point_clouds[0].radar_points[0].y_meters = 102.0F; // NOLINT: magic numbers are fine in tests
+    point_clouds[0].radar_points[0].z_meters = 103.0F; // NOLINT: magic numbers are fine in tests
+    point_clouds[0].radar_points[0].radar_relative_radial_velocity_m_s =
+        5.0F;                                                     // NOLINT: magic numbers are fine in tests
     point_clouds[0].radar_points[0].signal_to_noise_ratio = 5.0F; // NOLINT: magic numbers are fine in tests
     fix_when_received[0].position.east_meters = 879.020F;         // NOLINT: magic numbers are fine in tests
     fix_when_received[0].position.north_meters = 529.971F;        // NOLINT: magic numbers are fine in tests
@@ -945,10 +946,11 @@ static void test_accumulate_radar_point_cloud_rotation_and_move(void)
     // Point Cloud 1
     point_clouds[1].frame_index = 1;
     point_clouds[1].num_points_expected = point_clouds[1].num_points_received = 1;
-    point_clouds[1].radar_points[0].x_meters = 110.0F;            // NOLINT: magic numbers are fine in tests
-    point_clouds[1].radar_points[0].y_meters = 120.0F;            // NOLINT: magic numbers are fine in tests
-    point_clouds[1].radar_points[0].z_meters = 130.0F;            // NOLINT: magic numbers are fine in tests
-    point_clouds[1].radar_points[0].radar_relative_radial_velocity_m_s = 5.0F;          // NOLINT: magic numbers are fine in tests
+    point_clouds[1].radar_points[0].x_meters = 110.0F; // NOLINT: magic numbers are fine in tests
+    point_clouds[1].radar_points[0].y_meters = 120.0F; // NOLINT: magic numbers are fine in tests
+    point_clouds[1].radar_points[0].z_meters = 130.0F; // NOLINT: magic numbers are fine in tests
+    point_clouds[1].radar_points[0].radar_relative_radial_velocity_m_s =
+        5.0F;                                                     // NOLINT: magic numbers are fine in tests
     point_clouds[1].radar_points[0].signal_to_noise_ratio = 5.0F; // NOLINT: magic numbers are fine in tests
     fix_when_received[1].position.east_meters = 871.156F;         // NOLINT: magic numbers are fine in tests
     fix_when_received[1].position.north_meters = 548.981F;        // NOLINT: magic numbers are fine in tests
@@ -957,10 +959,11 @@ static void test_accumulate_radar_point_cloud_rotation_and_move(void)
     // Point Cloud 2
     point_clouds[2].frame_index = 2;
     point_clouds[2].num_points_expected = point_clouds[2].num_points_received = 1;
-    point_clouds[2].radar_points[0].x_meters = 200.0F;                    // NOLINT: magic numbers are fine in tests
-    point_clouds[2].radar_points[0].y_meters = 300.0F;                    // NOLINT: magic numbers are fine in tests
-    point_clouds[2].radar_points[0].z_meters = 400.0F;                    // NOLINT: magic numbers are fine in tests
-    point_clouds[2].radar_points[0].radar_relative_radial_velocity_m_s = 5.0F;                  // NOLINT: magic numbers are fine in tests
+    point_clouds[2].radar_points[0].x_meters = 200.0F; // NOLINT: magic numbers are fine in tests
+    point_clouds[2].radar_points[0].y_meters = 300.0F; // NOLINT: magic numbers are fine in tests
+    point_clouds[2].radar_points[0].z_meters = 400.0F; // NOLINT: magic numbers are fine in tests
+    point_clouds[2].radar_points[0].radar_relative_radial_velocity_m_s =
+        5.0F;                                                             // NOLINT: magic numbers are fine in tests
     point_clouds[2].radar_points[0].signal_to_noise_ratio = 5.0F;         // NOLINT: magic numbers are fine in tests
     fix_when_received[2].position.east_meters = 899.447F;                 // NOLINT: magic numbers are fine in tests
     fix_when_received[2].position.north_meters = 562.369F;                // NOLINT: magic numbers are fine in tests
@@ -1421,12 +1424,12 @@ static void test_provizio_accumulated_radar_point_cloud_iterator_get_point_end(v
         &iterator, NULL, accumulated_point_clouds, num_accumulated_point_clouds, &transformed_point,
         (float *)transformation_matrix);
     TEST_ASSERT_NULL(point);
-    TEST_ASSERT_EQUAL_FLOAT(0, transformed_point.x_meters);              // NOLINT
-    TEST_ASSERT_EQUAL_FLOAT(0, transformed_point.y_meters);              // NOLINT
-    TEST_ASSERT_EQUAL_FLOAT(0, transformed_point.z_meters);              // NOLINT
-    TEST_ASSERT_EQUAL_FLOAT(0, transformed_point.radar_relative_radial_velocity_m_s);          // NOLINT
-    TEST_ASSERT_EQUAL_FLOAT(0, transformed_point.signal_to_noise_ratio); // NOLINT
-    TEST_ASSERT_TRUE(                                                    // It checks it's all zeroes now
+    TEST_ASSERT_EQUAL_FLOAT(0, transformed_point.x_meters);                           // NOLINT
+    TEST_ASSERT_EQUAL_FLOAT(0, transformed_point.y_meters);                           // NOLINT
+    TEST_ASSERT_EQUAL_FLOAT(0, transformed_point.z_meters);                           // NOLINT
+    TEST_ASSERT_EQUAL_FLOAT(0, transformed_point.radar_relative_radial_velocity_m_s); // NOLINT
+    TEST_ASSERT_EQUAL_FLOAT(0, transformed_point.signal_to_noise_ratio);              // NOLINT
+    TEST_ASSERT_TRUE(                                                                 // It checks it's all zeroes now
         *((uint8_t *)transformation_matrix) == 0 &&
         memcmp(transformation_matrix, (uint8_t *)transformation_matrix + 1, // NOLINT
                sizeof(transformation_matrix) - 1) == 0);

--- a/test/c_99/src/test_radar_points_accumulation_filters.c
+++ b/test/c_99/src/test_radar_points_accumulation_filters.c
@@ -43,7 +43,7 @@ void test_provizio_radar_points_accumulation_filter_copy_all(void)
         in_points[i].signal_to_noise_ratio = 5.0F * i;              // NOLINT
     }
 
-    provizio_radar_point out_points[sizeof(in_points) / sizeof(in_points[0])] = {0};
+    provizio_radar_point out_points[sizeof(in_points) / sizeof(in_points[0])];
     memset(&out_points, 0, sizeof(out_points));
     uint16_t num_out_points = 0;
 

--- a/test/c_99/src/test_radar_points_accumulation_filters.c
+++ b/test/c_99/src/test_radar_points_accumulation_filters.c
@@ -36,11 +36,11 @@ void test_provizio_radar_points_accumulation_filter_copy_all(void)
     const uint16_t num_in_points = (uint16_t)(sizeof(in_points) / sizeof(in_points[0]));
     for (uint16_t i = 0; i < num_in_points; ++i)
     {
-        in_points[i].x_meters = 1.0F * i;              // NOLINT
-        in_points[i].y_meters = 2.0F * i;              // NOLINT
-        in_points[i].z_meters = 3.0F * i;              // NOLINT
-        in_points[i].radar_relative_radial_velocity_m_s = 4.0F * i;          // NOLINT
-        in_points[i].signal_to_noise_ratio = 5.0F * i; // NOLINT
+        in_points[i].x_meters = 1.0F * i;                           // NOLINT
+        in_points[i].y_meters = 2.0F * i;                           // NOLINT
+        in_points[i].z_meters = 3.0F * i;                           // NOLINT
+        in_points[i].radar_relative_radial_velocity_m_s = 4.0F * i; // NOLINT
+        in_points[i].signal_to_noise_ratio = 5.0F * i;              // NOLINT
     }
 
     provizio_radar_point out_points[sizeof(in_points) / sizeof(in_points[0])];
@@ -116,12 +116,12 @@ void test_provizio_radar_points_accumulation_filter_static_stationary_ego(void)
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].x_meters);                                       // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(1.0F, out_points[0].y_meters);                                       // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].z_meters);                                       // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(0.1F, out_points[0].radar_relative_radial_velocity_m_s);                                   // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(0.1F, out_points[0].radar_relative_radial_velocity_m_s);             // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(default_signal_to_noise_ratio, out_points[0].signal_to_noise_ratio); // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[1].x_meters);                                       // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(-1.0F, out_points[1].y_meters);                                      // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[1].z_meters);                                       // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(-0.1F, out_points[1].radar_relative_radial_velocity_m_s);                                  // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(-0.1F, out_points[1].radar_relative_radial_velocity_m_s);            // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(default_signal_to_noise_ratio, out_points[1].signal_to_noise_ratio); // NOLINT
 
         ++point_cloud->frame_index;
@@ -195,15 +195,17 @@ void test_provizio_radar_points_accumulation_filter_static_forward_radar(void)
                                                          accumulated_point_clouds, num_accumulated_clouds, &iterator,
                                                          NULL, out_points, &num_out_points);
         TEST_ASSERT_EQUAL_UINT16(2, num_out_points);
-        TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].x_meters);                                       // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(1.0F, out_points[0].y_meters);                                       // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].z_meters);                                       // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity + 0.1F, out_points[0].radar_relative_radial_velocity_m_s);         // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].x_meters); // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(1.0F, out_points[0].y_meters); // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].z_meters); // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity + 0.1F,
+                                out_points[0].radar_relative_radial_velocity_m_s);                   // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(default_signal_to_noise_ratio, out_points[0].signal_to_noise_ratio); // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[1].x_meters);                                       // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(-1.0F, out_points[1].y_meters);                                      // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[1].z_meters);                                       // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity - 0.1F, out_points[1].radar_relative_radial_velocity_m_s);         // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity - 0.1F,
+                                out_points[1].radar_relative_radial_velocity_m_s);                   // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(default_signal_to_noise_ratio, out_points[1].signal_to_noise_ratio); // NOLINT
 
         fix_when_received.position.east_meters += ego_velocity_m_s * time_between_frames_s;
@@ -265,19 +267,22 @@ void test_provizio_radar_points_accumulation_filter_static_rear_corner_radar(voi
         const float estimated_ego_velocity_radar_projection = -(float)M_SQRT2 / 2.0F * estimated_ego_velocity;
 
         // A static point at EgoRelative(0, 1, 0) -> RadarRelative(-sqrt(2)/2, -sqrt(2)/2, 0)
-        point_cloud->radar_points[0].x_meters = -(float)M_SQRT2 / 2.0F;                              // NOLINT
-        point_cloud->radar_points[0].y_meters = -(float)M_SQRT2 / 2.0F;                              // NOLINT
-        point_cloud->radar_points[0].radar_relative_radial_velocity_m_s = -estimated_ego_velocity_radar_projection + 0.1F; // NOLINT
+        point_cloud->radar_points[0].x_meters = -(float)M_SQRT2 / 2.0F; // NOLINT
+        point_cloud->radar_points[0].y_meters = -(float)M_SQRT2 / 2.0F; // NOLINT
+        point_cloud->radar_points[0].radar_relative_radial_velocity_m_s =
+            -estimated_ego_velocity_radar_projection + 0.1F; // NOLINT
         point_cloud->radar_points[0].signal_to_noise_ratio = default_signal_to_noise_ratio;
         // A static point at EgoRelative(0, -1, 0) -> RadarRelative(-sqrt(2)*3/2, sqrt(2)/2, 0)
-        point_cloud->radar_points[1].x_meters = -(float)M_SQRT2 * 3.0F / 2.0F;                       // NOLINT
-        point_cloud->radar_points[1].y_meters = (float)M_SQRT2 / 2.0F;                               // NOLINT
-        point_cloud->radar_points[1].radar_relative_radial_velocity_m_s = -estimated_ego_velocity_radar_projection - 0.1F; // NOLINT
+        point_cloud->radar_points[1].x_meters = -(float)M_SQRT2 * 3.0F / 2.0F; // NOLINT
+        point_cloud->radar_points[1].y_meters = (float)M_SQRT2 / 2.0F;         // NOLINT
+        point_cloud->radar_points[1].radar_relative_radial_velocity_m_s =
+            -estimated_ego_velocity_radar_projection - 0.1F; // NOLINT
         point_cloud->radar_points[1].signal_to_noise_ratio = default_signal_to_noise_ratio;
         // A moving point at EgoRelative(1, 0, 0) -> RadarRelative(-sqrt(2)*3/2, -sqrt(2)/2, 0)
-        point_cloud->radar_points[2].x_meters = -(float)M_SQRT2 * 3.0F / 2.0F;                        // NOLINT
-        point_cloud->radar_points[2].y_meters = -(float)M_SQRT2 / 2.0F;                               // NOLINT
-        point_cloud->radar_points[2].radar_relative_radial_velocity_m_s = -estimated_ego_velocity_radar_projection + 10.0F; // NOLINT
+        point_cloud->radar_points[2].x_meters = -(float)M_SQRT2 * 3.0F / 2.0F; // NOLINT
+        point_cloud->radar_points[2].y_meters = -(float)M_SQRT2 / 2.0F;        // NOLINT
+        point_cloud->radar_points[2].radar_relative_radial_velocity_m_s =
+            -estimated_ego_velocity_radar_projection + 10.0F; // NOLINT
         point_cloud->radar_points[2].signal_to_noise_ratio = default_signal_to_noise_ratio;
 
         iterator = provizio_accumulate_radar_point_cloud(point_cloud, &radar_fix, accumulated_point_clouds,
@@ -286,16 +291,18 @@ void test_provizio_radar_points_accumulation_filter_static_rear_corner_radar(voi
                                                          accumulated_point_clouds, num_accumulated_clouds, &iterator,
                                                          NULL, out_points, &num_out_points);
         TEST_ASSERT_EQUAL_UINT16(2, num_out_points);
-        TEST_ASSERT_EQUAL_FLOAT(-(float)M_SQRT2 / 2.0F, out_points[0].x_meters);                              // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(-(float)M_SQRT2 / 2.0F, out_points[0].y_meters);                              // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].z_meters);                                                // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity_radar_projection + 0.1F, out_points[0].radar_relative_radial_velocity_m_s); // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(default_signal_to_noise_ratio, out_points[0].signal_to_noise_ratio);          // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(-(float)M_SQRT2 * 3.0F / 2.0F, out_points[1].x_meters);                       // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT((float)M_SQRT2 / 2.0F, out_points[1].y_meters);                               // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[1].z_meters);                                                // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity_radar_projection - 0.1F, out_points[1].radar_relative_radial_velocity_m_s); // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(default_signal_to_noise_ratio, out_points[1].signal_to_noise_ratio);          // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(-(float)M_SQRT2 / 2.0F, out_points[0].x_meters); // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(-(float)M_SQRT2 / 2.0F, out_points[0].y_meters); // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].z_meters);                   // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity_radar_projection + 0.1F,
+                                out_points[0].radar_relative_radial_velocity_m_s);                   // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(default_signal_to_noise_ratio, out_points[0].signal_to_noise_ratio); // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(-(float)M_SQRT2 * 3.0F / 2.0F, out_points[1].x_meters);              // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT((float)M_SQRT2 / 2.0F, out_points[1].y_meters);                      // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[1].z_meters);                                       // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity_radar_projection - 0.1F,
+                                out_points[1].radar_relative_radial_velocity_m_s);                   // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(default_signal_to_noise_ratio, out_points[1].signal_to_noise_ratio); // NOLINT
 
         ego_fix.position.east_meters += ego_velocity_m_s * time_between_frames_s;
         radar_fix.position.east_meters = ego_fix.position.east_meters - 1.0F;
@@ -371,15 +378,17 @@ void test_provizio_radar_points_accumulation_filter_static_move_up(void)
                                                          accumulated_point_clouds, num_accumulated_clouds, &iterator,
                                                          NULL, out_points, &num_out_points);
         TEST_ASSERT_EQUAL_UINT16(2, num_out_points);
-        TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].x_meters);                                       // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(1.0F, out_points[0].y_meters);                                       // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].z_meters);                                       // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity + 0.1F, out_points[0].radar_relative_radial_velocity_m_s);         // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].x_meters); // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(1.0F, out_points[0].y_meters); // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].z_meters); // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity + 0.1F,
+                                out_points[0].radar_relative_radial_velocity_m_s);                   // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(default_signal_to_noise_ratio, out_points[0].signal_to_noise_ratio); // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[1].x_meters);                                       // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(-1.0F, out_points[1].y_meters);                                      // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[1].z_meters);                                       // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity - 0.1F, out_points[1].radar_relative_radial_velocity_m_s);         // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity - 0.1F,
+                                out_points[1].radar_relative_radial_velocity_m_s);                   // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(default_signal_to_noise_ratio, out_points[1].signal_to_noise_ratio); // NOLINT
 
         fix_when_received.position.up_meters += ego_velocity_m_s * time_between_frames_s;
@@ -455,15 +464,17 @@ void test_provizio_radar_points_accumulation_filter_static_move_down(void)
                                                          accumulated_point_clouds, num_accumulated_clouds, &iterator,
                                                          NULL, out_points, &num_out_points);
         TEST_ASSERT_EQUAL_UINT16(2, num_out_points);
-        TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].x_meters);                                       // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(1.0F, out_points[0].y_meters);                                       // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].z_meters);                                       // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity + 0.1F, out_points[0].radar_relative_radial_velocity_m_s);         // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].x_meters); // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(1.0F, out_points[0].y_meters); // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].z_meters); // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity + 0.1F,
+                                out_points[0].radar_relative_radial_velocity_m_s);                   // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(default_signal_to_noise_ratio, out_points[0].signal_to_noise_ratio); // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[1].x_meters);                                       // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(-1.0F, out_points[1].y_meters);                                      // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[1].z_meters);                                       // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity - 0.1F, out_points[1].radar_relative_radial_velocity_m_s);         // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity - 0.1F,
+                                out_points[1].radar_relative_radial_velocity_m_s);                   // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(default_signal_to_noise_ratio, out_points[1].signal_to_noise_ratio); // NOLINT
 
         fix_when_received.position.up_meters -= ego_velocity_m_s * time_between_frames_s;

--- a/test/c_99/src/test_radar_points_accumulation_filters.c
+++ b/test/c_99/src/test_radar_points_accumulation_filters.c
@@ -39,7 +39,7 @@ void test_provizio_radar_points_accumulation_filter_copy_all(void)
         in_points[i].x_meters = 1.0F * i;              // NOLINT
         in_points[i].y_meters = 2.0F * i;              // NOLINT
         in_points[i].z_meters = 3.0F * i;              // NOLINT
-        in_points[i].velocity_m_s = 4.0F * i;          // NOLINT
+        in_points[i].radar_relative_radial_velocity_m_s = 4.0F * i;          // NOLINT
         in_points[i].signal_to_noise_ratio = 5.0F * i; // NOLINT
     }
 
@@ -94,17 +94,17 @@ void test_provizio_radar_points_accumulation_filter_static_stationary_ego(void)
         // A static point at EgoRelative(0, 1, 0)
         point_cloud->radar_points[0].x_meters = 0.0F;
         point_cloud->radar_points[0].y_meters = 1.0F;
-        point_cloud->radar_points[0].velocity_m_s = 0.1F; // NOLINT
+        point_cloud->radar_points[0].radar_relative_radial_velocity_m_s = 0.1F; // NOLINT
         point_cloud->radar_points[0].signal_to_noise_ratio = default_signal_to_noise_ratio;
         // A static point at EgoRelative(0, -1, 0)
         point_cloud->radar_points[1].x_meters = 0.0F;
         point_cloud->radar_points[1].y_meters = -1.0F;
-        point_cloud->radar_points[1].velocity_m_s = -0.1F; // NOLINT
+        point_cloud->radar_points[1].radar_relative_radial_velocity_m_s = -0.1F; // NOLINT
         point_cloud->radar_points[1].signal_to_noise_ratio = default_signal_to_noise_ratio;
         // A moving point at EgoRelative(1, 0, 0)
         point_cloud->radar_points[2].x_meters = 1.0F;
         point_cloud->radar_points[2].y_meters = 0.0F;
-        point_cloud->radar_points[2].velocity_m_s = 10.0F; // NOLINT
+        point_cloud->radar_points[2].radar_relative_radial_velocity_m_s = 10.0F; // NOLINT
         point_cloud->radar_points[2].signal_to_noise_ratio = default_signal_to_noise_ratio;
 
         iterator = provizio_accumulate_radar_point_cloud(point_cloud, &the_fix, accumulated_point_clouds,
@@ -116,12 +116,12 @@ void test_provizio_radar_points_accumulation_filter_static_stationary_ego(void)
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].x_meters);                                       // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(1.0F, out_points[0].y_meters);                                       // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].z_meters);                                       // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(0.1F, out_points[0].velocity_m_s);                                   // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(0.1F, out_points[0].radar_relative_radial_velocity_m_s);                                   // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(default_signal_to_noise_ratio, out_points[0].signal_to_noise_ratio); // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[1].x_meters);                                       // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(-1.0F, out_points[1].y_meters);                                      // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[1].z_meters);                                       // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(-0.1F, out_points[1].velocity_m_s);                                  // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(-0.1F, out_points[1].radar_relative_radial_velocity_m_s);                                  // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(default_signal_to_noise_ratio, out_points[1].signal_to_noise_ratio); // NOLINT
 
         ++point_cloud->frame_index;
@@ -176,17 +176,17 @@ void test_provizio_radar_points_accumulation_filter_static_forward_radar(void)
         // A static point at EgoRelative(0, 1, 0)
         point_cloud->radar_points[0].x_meters = 0.0F;
         point_cloud->radar_points[0].y_meters = 1.0F;
-        point_cloud->radar_points[0].velocity_m_s = -estimated_ego_velocity + 0.1F; // NOLINT
+        point_cloud->radar_points[0].radar_relative_radial_velocity_m_s = -estimated_ego_velocity + 0.1F; // NOLINT
         point_cloud->radar_points[0].signal_to_noise_ratio = default_signal_to_noise_ratio;
         // A static point at EgoRelative(0, -1, 0)
         point_cloud->radar_points[1].x_meters = 0.0F;
         point_cloud->radar_points[1].y_meters = -1.0F;
-        point_cloud->radar_points[1].velocity_m_s = -estimated_ego_velocity - 0.1F; // NOLINT
+        point_cloud->radar_points[1].radar_relative_radial_velocity_m_s = -estimated_ego_velocity - 0.1F; // NOLINT
         point_cloud->radar_points[1].signal_to_noise_ratio = default_signal_to_noise_ratio;
         // A moving point at EgoRelative(1, 0, 0)
         point_cloud->radar_points[2].x_meters = 1.0F;
         point_cloud->radar_points[2].y_meters = 0.0F;
-        point_cloud->radar_points[2].velocity_m_s = -estimated_ego_velocity + 10.0F; // NOLINT
+        point_cloud->radar_points[2].radar_relative_radial_velocity_m_s = -estimated_ego_velocity + 10.0F; // NOLINT
         point_cloud->radar_points[2].signal_to_noise_ratio = default_signal_to_noise_ratio;
 
         iterator = provizio_accumulate_radar_point_cloud(point_cloud, &fix_when_received, accumulated_point_clouds,
@@ -198,12 +198,12 @@ void test_provizio_radar_points_accumulation_filter_static_forward_radar(void)
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].x_meters);                                       // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(1.0F, out_points[0].y_meters);                                       // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].z_meters);                                       // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity + 0.1F, out_points[0].velocity_m_s);         // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity + 0.1F, out_points[0].radar_relative_radial_velocity_m_s);         // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(default_signal_to_noise_ratio, out_points[0].signal_to_noise_ratio); // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[1].x_meters);                                       // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(-1.0F, out_points[1].y_meters);                                      // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[1].z_meters);                                       // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity - 0.1F, out_points[1].velocity_m_s);         // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity - 0.1F, out_points[1].radar_relative_radial_velocity_m_s);         // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(default_signal_to_noise_ratio, out_points[1].signal_to_noise_ratio); // NOLINT
 
         fix_when_received.position.east_meters += ego_velocity_m_s * time_between_frames_s;
@@ -267,17 +267,17 @@ void test_provizio_radar_points_accumulation_filter_static_rear_corner_radar(voi
         // A static point at EgoRelative(0, 1, 0) -> RadarRelative(-sqrt(2)/2, -sqrt(2)/2, 0)
         point_cloud->radar_points[0].x_meters = -(float)M_SQRT2 / 2.0F;                              // NOLINT
         point_cloud->radar_points[0].y_meters = -(float)M_SQRT2 / 2.0F;                              // NOLINT
-        point_cloud->radar_points[0].velocity_m_s = -estimated_ego_velocity_radar_projection + 0.1F; // NOLINT
+        point_cloud->radar_points[0].radar_relative_radial_velocity_m_s = -estimated_ego_velocity_radar_projection + 0.1F; // NOLINT
         point_cloud->radar_points[0].signal_to_noise_ratio = default_signal_to_noise_ratio;
         // A static point at EgoRelative(0, -1, 0) -> RadarRelative(-sqrt(2)*3/2, sqrt(2)/2, 0)
         point_cloud->radar_points[1].x_meters = -(float)M_SQRT2 * 3.0F / 2.0F;                       // NOLINT
         point_cloud->radar_points[1].y_meters = (float)M_SQRT2 / 2.0F;                               // NOLINT
-        point_cloud->radar_points[1].velocity_m_s = -estimated_ego_velocity_radar_projection - 0.1F; // NOLINT
+        point_cloud->radar_points[1].radar_relative_radial_velocity_m_s = -estimated_ego_velocity_radar_projection - 0.1F; // NOLINT
         point_cloud->radar_points[1].signal_to_noise_ratio = default_signal_to_noise_ratio;
         // A moving point at EgoRelative(1, 0, 0) -> RadarRelative(-sqrt(2)*3/2, -sqrt(2)/2, 0)
         point_cloud->radar_points[2].x_meters = -(float)M_SQRT2 * 3.0F / 2.0F;                        // NOLINT
         point_cloud->radar_points[2].y_meters = -(float)M_SQRT2 / 2.0F;                               // NOLINT
-        point_cloud->radar_points[2].velocity_m_s = -estimated_ego_velocity_radar_projection + 10.0F; // NOLINT
+        point_cloud->radar_points[2].radar_relative_radial_velocity_m_s = -estimated_ego_velocity_radar_projection + 10.0F; // NOLINT
         point_cloud->radar_points[2].signal_to_noise_ratio = default_signal_to_noise_ratio;
 
         iterator = provizio_accumulate_radar_point_cloud(point_cloud, &radar_fix, accumulated_point_clouds,
@@ -289,12 +289,12 @@ void test_provizio_radar_points_accumulation_filter_static_rear_corner_radar(voi
         TEST_ASSERT_EQUAL_FLOAT(-(float)M_SQRT2 / 2.0F, out_points[0].x_meters);                              // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(-(float)M_SQRT2 / 2.0F, out_points[0].y_meters);                              // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].z_meters);                                                // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity_radar_projection + 0.1F, out_points[0].velocity_m_s); // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity_radar_projection + 0.1F, out_points[0].radar_relative_radial_velocity_m_s); // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(default_signal_to_noise_ratio, out_points[0].signal_to_noise_ratio);          // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(-(float)M_SQRT2 * 3.0F / 2.0F, out_points[1].x_meters);                       // NOLINT
         TEST_ASSERT_EQUAL_FLOAT((float)M_SQRT2 / 2.0F, out_points[1].y_meters);                               // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[1].z_meters);                                                // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity_radar_projection - 0.1F, out_points[1].velocity_m_s); // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity_radar_projection - 0.1F, out_points[1].radar_relative_radial_velocity_m_s); // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(default_signal_to_noise_ratio, out_points[1].signal_to_noise_ratio);          // NOLINT
 
         ego_fix.position.east_meters += ego_velocity_m_s * time_between_frames_s;
@@ -352,17 +352,17 @@ void test_provizio_radar_points_accumulation_filter_static_move_up(void)
         // A static point at EgoRelative(0, 1, 0)
         point_cloud->radar_points[0].x_meters = 0.0F;
         point_cloud->radar_points[0].y_meters = 1.0F;
-        point_cloud->radar_points[0].velocity_m_s = -estimated_ego_velocity + 0.1F; // NOLINT
+        point_cloud->radar_points[0].radar_relative_radial_velocity_m_s = -estimated_ego_velocity + 0.1F; // NOLINT
         point_cloud->radar_points[0].signal_to_noise_ratio = default_signal_to_noise_ratio;
         // A static point at EgoRelative(0, -1, 0)
         point_cloud->radar_points[1].x_meters = 0.0F;
         point_cloud->radar_points[1].y_meters = -1.0F;
-        point_cloud->radar_points[1].velocity_m_s = -estimated_ego_velocity - 0.1F; // NOLINT
+        point_cloud->radar_points[1].radar_relative_radial_velocity_m_s = -estimated_ego_velocity - 0.1F; // NOLINT
         point_cloud->radar_points[1].signal_to_noise_ratio = default_signal_to_noise_ratio;
         // A moving point at EgoRelative(1, 0, 0)
         point_cloud->radar_points[2].x_meters = 1.0F;
         point_cloud->radar_points[2].y_meters = 0.0F;
-        point_cloud->radar_points[2].velocity_m_s = -estimated_ego_velocity + 10.0F; // NOLINT
+        point_cloud->radar_points[2].radar_relative_radial_velocity_m_s = -estimated_ego_velocity + 10.0F; // NOLINT
         point_cloud->radar_points[2].signal_to_noise_ratio = default_signal_to_noise_ratio;
 
         iterator = provizio_accumulate_radar_point_cloud(point_cloud, &fix_when_received, accumulated_point_clouds,
@@ -374,12 +374,12 @@ void test_provizio_radar_points_accumulation_filter_static_move_up(void)
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].x_meters);                                       // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(1.0F, out_points[0].y_meters);                                       // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].z_meters);                                       // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity + 0.1F, out_points[0].velocity_m_s);         // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity + 0.1F, out_points[0].radar_relative_radial_velocity_m_s);         // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(default_signal_to_noise_ratio, out_points[0].signal_to_noise_ratio); // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[1].x_meters);                                       // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(-1.0F, out_points[1].y_meters);                                      // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[1].z_meters);                                       // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity - 0.1F, out_points[1].velocity_m_s);         // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity - 0.1F, out_points[1].radar_relative_radial_velocity_m_s);         // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(default_signal_to_noise_ratio, out_points[1].signal_to_noise_ratio); // NOLINT
 
         fix_when_received.position.up_meters += ego_velocity_m_s * time_between_frames_s;
@@ -436,17 +436,17 @@ void test_provizio_radar_points_accumulation_filter_static_move_down(void)
         // A static point at EgoRelative(0, 1, 0)
         point_cloud->radar_points[0].x_meters = 0.0F;
         point_cloud->radar_points[0].y_meters = 1.0F;
-        point_cloud->radar_points[0].velocity_m_s = -estimated_ego_velocity + 0.1F; // NOLINT
+        point_cloud->radar_points[0].radar_relative_radial_velocity_m_s = -estimated_ego_velocity + 0.1F; // NOLINT
         point_cloud->radar_points[0].signal_to_noise_ratio = default_signal_to_noise_ratio;
         // A static point at EgoRelative(0, -1, 0)
         point_cloud->radar_points[1].x_meters = 0.0F;
         point_cloud->radar_points[1].y_meters = -1.0F;
-        point_cloud->radar_points[1].velocity_m_s = -estimated_ego_velocity - 0.1F; // NOLINT
+        point_cloud->radar_points[1].radar_relative_radial_velocity_m_s = -estimated_ego_velocity - 0.1F; // NOLINT
         point_cloud->radar_points[1].signal_to_noise_ratio = default_signal_to_noise_ratio;
         // A moving point at EgoRelative(1, 0, 0)
         point_cloud->radar_points[2].x_meters = 1.0F;
         point_cloud->radar_points[2].y_meters = 0.0F;
-        point_cloud->radar_points[2].velocity_m_s = -estimated_ego_velocity + 10.0F; // NOLINT
+        point_cloud->radar_points[2].radar_relative_radial_velocity_m_s = -estimated_ego_velocity + 10.0F; // NOLINT
         point_cloud->radar_points[2].signal_to_noise_ratio = default_signal_to_noise_ratio;
 
         iterator = provizio_accumulate_radar_point_cloud(point_cloud, &fix_when_received, accumulated_point_clouds,
@@ -458,12 +458,12 @@ void test_provizio_radar_points_accumulation_filter_static_move_down(void)
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].x_meters);                                       // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(1.0F, out_points[0].y_meters);                                       // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].z_meters);                                       // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity + 0.1F, out_points[0].velocity_m_s);         // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity + 0.1F, out_points[0].radar_relative_radial_velocity_m_s);         // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(default_signal_to_noise_ratio, out_points[0].signal_to_noise_ratio); // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[1].x_meters);                                       // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(-1.0F, out_points[1].y_meters);                                      // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[1].z_meters);                                       // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity - 0.1F, out_points[1].velocity_m_s);         // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity - 0.1F, out_points[1].radar_relative_radial_velocity_m_s);         // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(default_signal_to_noise_ratio, out_points[1].signal_to_noise_ratio); // NOLINT
 
         fix_when_received.position.up_meters -= ego_velocity_m_s * time_between_frames_s;

--- a/test/c_99/src/test_radar_points_accumulation_filters.c
+++ b/test/c_99/src/test_radar_points_accumulation_filters.c
@@ -195,17 +195,17 @@ void test_provizio_radar_points_accumulation_filter_static_forward_radar(void)
                                                          accumulated_point_clouds, num_accumulated_clouds, &iterator,
                                                          NULL, out_points, &num_out_points);
         TEST_ASSERT_EQUAL_UINT16(2, num_out_points);
-        TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].x_meters); // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(1.0F, out_points[0].y_meters); // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].z_meters); // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity + 0.1F,
-                                out_points[0].radar_relative_radial_velocity_m_s);                   // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].x_meters);  // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(1.0F, out_points[0].y_meters);  // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].z_meters);  // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity + 0.1F, // NOLINT
+                                out_points[0].radar_relative_radial_velocity_m_s);
         TEST_ASSERT_EQUAL_FLOAT(default_signal_to_noise_ratio, out_points[0].signal_to_noise_ratio); // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[1].x_meters);                                       // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(-1.0F, out_points[1].y_meters);                                      // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[1].z_meters);                                       // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity - 0.1F,
-                                out_points[1].radar_relative_radial_velocity_m_s);                   // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity - 0.1F,                                      // NOLINT
+                                out_points[1].radar_relative_radial_velocity_m_s);
         TEST_ASSERT_EQUAL_FLOAT(default_signal_to_noise_ratio, out_points[1].signal_to_noise_ratio); // NOLINT
 
         fix_when_received.position.east_meters += ego_velocity_m_s * time_between_frames_s;
@@ -294,14 +294,14 @@ void test_provizio_radar_points_accumulation_filter_static_rear_corner_radar(voi
         TEST_ASSERT_EQUAL_FLOAT(-(float)M_SQRT2 / 2.0F, out_points[0].x_meters); // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(-(float)M_SQRT2 / 2.0F, out_points[0].y_meters); // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].z_meters);                   // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity_radar_projection + 0.1F,
-                                out_points[0].radar_relative_radial_velocity_m_s);                   // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity_radar_projection + 0.1F, // NOLINT
+                                out_points[0].radar_relative_radial_velocity_m_s);
         TEST_ASSERT_EQUAL_FLOAT(default_signal_to_noise_ratio, out_points[0].signal_to_noise_ratio); // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(-(float)M_SQRT2 * 3.0F / 2.0F, out_points[1].x_meters);              // NOLINT
         TEST_ASSERT_EQUAL_FLOAT((float)M_SQRT2 / 2.0F, out_points[1].y_meters);                      // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[1].z_meters);                                       // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity_radar_projection - 0.1F,
-                                out_points[1].radar_relative_radial_velocity_m_s);                   // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity_radar_projection - 0.1F,                     // NOLINT
+                                out_points[1].radar_relative_radial_velocity_m_s);
         TEST_ASSERT_EQUAL_FLOAT(default_signal_to_noise_ratio, out_points[1].signal_to_noise_ratio); // NOLINT
 
         ego_fix.position.east_meters += ego_velocity_m_s * time_between_frames_s;
@@ -378,17 +378,17 @@ void test_provizio_radar_points_accumulation_filter_static_move_up(void)
                                                          accumulated_point_clouds, num_accumulated_clouds, &iterator,
                                                          NULL, out_points, &num_out_points);
         TEST_ASSERT_EQUAL_UINT16(2, num_out_points);
-        TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].x_meters); // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(1.0F, out_points[0].y_meters); // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].z_meters); // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity + 0.1F,
-                                out_points[0].radar_relative_radial_velocity_m_s);                   // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].x_meters);  // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(1.0F, out_points[0].y_meters);  // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].z_meters);  // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity + 0.1F, // NOLINT
+                                out_points[0].radar_relative_radial_velocity_m_s);
         TEST_ASSERT_EQUAL_FLOAT(default_signal_to_noise_ratio, out_points[0].signal_to_noise_ratio); // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[1].x_meters);                                       // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(-1.0F, out_points[1].y_meters);                                      // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[1].z_meters);                                       // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity - 0.1F,
-                                out_points[1].radar_relative_radial_velocity_m_s);                   // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity - 0.1F,                                      // NOLINT
+                                out_points[1].radar_relative_radial_velocity_m_s);
         TEST_ASSERT_EQUAL_FLOAT(default_signal_to_noise_ratio, out_points[1].signal_to_noise_ratio); // NOLINT
 
         fix_when_received.position.up_meters += ego_velocity_m_s * time_between_frames_s;
@@ -464,17 +464,17 @@ void test_provizio_radar_points_accumulation_filter_static_move_down(void)
                                                          accumulated_point_clouds, num_accumulated_clouds, &iterator,
                                                          NULL, out_points, &num_out_points);
         TEST_ASSERT_EQUAL_UINT16(2, num_out_points);
-        TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].x_meters); // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(1.0F, out_points[0].y_meters); // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].z_meters); // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity + 0.1F,
-                                out_points[0].radar_relative_radial_velocity_m_s);                   // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].x_meters);  // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(1.0F, out_points[0].y_meters);  // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[0].z_meters);  // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity + 0.1F, // NOLINT
+                                out_points[0].radar_relative_radial_velocity_m_s);
         TEST_ASSERT_EQUAL_FLOAT(default_signal_to_noise_ratio, out_points[0].signal_to_noise_ratio); // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[1].x_meters);                                       // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(-1.0F, out_points[1].y_meters);                                      // NOLINT
         TEST_ASSERT_EQUAL_FLOAT(0.0F, out_points[1].z_meters);                                       // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity - 0.1F,
-                                out_points[1].radar_relative_radial_velocity_m_s);                   // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(-estimated_ego_velocity - 0.1F,                                      // NOLINT
+                                out_points[1].radar_relative_radial_velocity_m_s);
         TEST_ASSERT_EQUAL_FLOAT(default_signal_to_noise_ratio, out_points[1].signal_to_noise_ratio); // NOLINT
 
         fix_when_received.position.up_meters -= ego_velocity_m_s * time_between_frames_s;

--- a/test/c_99/src/test_radar_points_accumulation_filters.c
+++ b/test/c_99/src/test_radar_points_accumulation_filters.c
@@ -32,7 +32,7 @@ void test_provizio_radar_points_accumulation_filter_copy_all_empty(void)
 
 void test_provizio_radar_points_accumulation_filter_copy_all(void)
 {
-    provizio_radar_point in_points[5]; // NOLINT
+    provizio_radar_point in_points[5] = {0}; // NOLINT
     const uint16_t num_in_points = (uint16_t)(sizeof(in_points) / sizeof(in_points[0]));
     for (uint16_t i = 0; i < num_in_points; ++i)
     {
@@ -43,7 +43,7 @@ void test_provizio_radar_points_accumulation_filter_copy_all(void)
         in_points[i].signal_to_noise_ratio = 5.0F * i;              // NOLINT
     }
 
-    provizio_radar_point out_points[sizeof(in_points) / sizeof(in_points[0])];
+    provizio_radar_point out_points[sizeof(in_points) / sizeof(in_points[0])] = {0};
     memset(&out_points, 0, sizeof(out_points));
     uint16_t num_out_points = 0;
 

--- a/test/c_99/src/test_radar_points_accumulation_filters.c
+++ b/test/c_99/src/test_radar_points_accumulation_filters.c
@@ -32,7 +32,7 @@ void test_provizio_radar_points_accumulation_filter_copy_all_empty(void)
 
 void test_provizio_radar_points_accumulation_filter_copy_all(void)
 {
-    provizio_radar_point in_points[5] = {0}; // NOLINT
+    provizio_radar_point in_points[5]; // NOLINT
     const uint16_t num_in_points = (uint16_t)(sizeof(in_points) / sizeof(in_points[0]));
     for (uint16_t i = 0; i < num_in_points; ++i)
     {

--- a/test/c_99/src/test_radar_points_accumulation_filters.c
+++ b/test/c_99/src/test_radar_points_accumulation_filters.c
@@ -36,11 +36,12 @@ void test_provizio_radar_points_accumulation_filter_copy_all(void)
     const uint16_t num_in_points = (uint16_t)(sizeof(in_points) / sizeof(in_points[0]));
     for (uint16_t i = 0; i < num_in_points; ++i)
     {
-        in_points[i].x_meters = 1.0F * i;                           // NOLINT
-        in_points[i].y_meters = 2.0F * i;                           // NOLINT
-        in_points[i].z_meters = 3.0F * i;                           // NOLINT
-        in_points[i].radar_relative_radial_velocity_m_s = 4.0F * i; // NOLINT
-        in_points[i].signal_to_noise_ratio = 5.0F * i;              // NOLINT
+        in_points[i].x_meters = 1.0F * i;                            // NOLINT
+        in_points[i].y_meters = 2.0F * i;                            // NOLINT
+        in_points[i].z_meters = 3.0F * i;                            // NOLINT
+        in_points[i].radar_relative_radial_velocity_m_s = 4.0F * i;  // NOLINT
+        in_points[i].signal_to_noise_ratio = 5.0F * i;               // NOLINT
+        in_points[i].ground_relative_radial_velocity_m_s = 4.0F * i; // NOLINT
     }
 
     provizio_radar_point out_points[sizeof(in_points) / sizeof(in_points[0])];

--- a/test/cpp_14/CMakeLists.txt
+++ b/test/cpp_14/CMakeLists.txt
@@ -1,23 +1,26 @@
 # Copyright 2022 Provizio Ltd.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
 
 cmake_minimum_required(VERSION 3.1.0)
 
 find_package(Threads)
 add_executable(provizio_radar_api_core_test_cpp_14 src/smoketest.cpp)
-target_link_libraries(provizio_radar_api_core_test_cpp_14 provizio_radar_api_core Threads::Threads)
-set_property(TARGET provizio_radar_api_core_test_cpp_14 PROPERTY CXX_STANDARD 14)
+target_link_libraries(provizio_radar_api_core_test_cpp_14
+                      provizio_radar_api_core Threads::Threads)
+set_property(TARGET provizio_radar_api_core_test_cpp_14 PROPERTY CXX_STANDARD
+                                                                 14)
 add_dependencies(provizio_radar_api_core_test_cpp_14 unity)
 
-add_test(NAME provizio_radar_api_core_test_cpp_14 COMMAND provizio_radar_api_core_test_cpp_14)
+add_test(NAME provizio_radar_api_core_test_cpp_14
+         COMMAND provizio_radar_api_core_test_cpp_14)

--- a/test/cpp_14/src/smoketest.cpp
+++ b/test/cpp_14/src/smoketest.cpp
@@ -157,6 +157,8 @@ int main(int argc, char *argv[])
                                                   point_velocity);
                 provizio_set_protocol_field_float(&packet.radar_points[0].signal_to_noise_ratio,
                                                   point_signal_to_noise_ratio);
+                provizio_set_protocol_field_float(&packet.radar_points[0].ground_relative_radial_velocity_m_s,
+                                                  -point_velocity);
 
                 for (auto frame_index = start_frame_index; !finish; ++frame_index) // NOLINT: Don't unroll
                 {
@@ -241,7 +243,8 @@ int main(int argc, char *argv[])
                 received_point_cloud->radar_points[0].y_meters != point_y ||
                 received_point_cloud->radar_points[0].z_meters != point_z ||
                 received_point_cloud->radar_points[0].radar_relative_radial_velocity_m_s != point_velocity ||
-                received_point_cloud->radar_points[0].signal_to_noise_ratio != point_signal_to_noise_ratio)
+                received_point_cloud->radar_points[0].signal_to_noise_ratio != point_signal_to_noise_ratio ||
+                received_point_cloud->radar_points[0].ground_relative_radial_velocity_m_s != -point_velocity)
             {
                 throw std::runtime_error{"Incorrect point cloud received"}; // LCOV_EXCL_LINE: Shouldn't happen
             }

--- a/test/cpp_14/src/smoketest.cpp
+++ b/test/cpp_14/src/smoketest.cpp
@@ -153,7 +153,8 @@ int main(int argc, char *argv[])
                 provizio_set_protocol_field_float(&packet.radar_points[0].x_meters, point_x);
                 provizio_set_protocol_field_float(&packet.radar_points[0].y_meters, point_y);
                 provizio_set_protocol_field_float(&packet.radar_points[0].z_meters, point_z);
-                provizio_set_protocol_field_float(&packet.radar_points[0].radar_relative_radial_velocity_m_s, point_velocity);
+                provizio_set_protocol_field_float(&packet.radar_points[0].radar_relative_radial_velocity_m_s,
+                                                  point_velocity);
                 provizio_set_protocol_field_float(&packet.radar_points[0].signal_to_noise_ratio,
                                                   point_signal_to_noise_ratio);
 

--- a/test/cpp_14/src/smoketest.cpp
+++ b/test/cpp_14/src/smoketest.cpp
@@ -153,7 +153,7 @@ int main(int argc, char *argv[])
                 provizio_set_protocol_field_float(&packet.radar_points[0].x_meters, point_x);
                 provizio_set_protocol_field_float(&packet.radar_points[0].y_meters, point_y);
                 provizio_set_protocol_field_float(&packet.radar_points[0].z_meters, point_z);
-                provizio_set_protocol_field_float(&packet.radar_points[0].velocity_m_s, point_velocity);
+                provizio_set_protocol_field_float(&packet.radar_points[0].radar_relative_radial_velocity_m_s, point_velocity);
                 provizio_set_protocol_field_float(&packet.radar_points[0].signal_to_noise_ratio,
                                                   point_signal_to_noise_ratio);
 
@@ -239,7 +239,7 @@ int main(int argc, char *argv[])
                 received_point_cloud->radar_points[0].x_meters != point_x ||
                 received_point_cloud->radar_points[0].y_meters != point_y ||
                 received_point_cloud->radar_points[0].z_meters != point_z ||
-                received_point_cloud->radar_points[0].velocity_m_s != point_velocity ||
+                received_point_cloud->radar_points[0].radar_relative_radial_velocity_m_s != point_velocity ||
                 received_point_cloud->radar_points[0].signal_to_noise_ratio != point_signal_to_noise_ratio)
             {
                 throw std::runtime_error{"Incorrect point cloud received"}; // LCOV_EXCL_LINE: Shouldn't happen


### PR DESCRIPTION
This branch appends a new floating point value,  ground_relative_radial_velocity_m_s, to the provizio_radar_point structure used for point clouds and updates the UDP Point Cloud Protocol Version number to 2.