### PR TITLE
APT-9227: Setting range sends both an ackowledgement (when request received) and response (when complete)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     name: Check license headers
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: .github/workflows/check_license_headers.sh
 
   build-nix:
@@ -17,14 +17,14 @@ jobs:
     runs-on: ${{matrix.runner}}
     strategy:
       matrix:
-        runner: [ubuntu-latest, ubuntu-20.04, macos-latest, linux_arm]
+        runner: [ubuntu-latest, ubuntu-22.04, macos-latest, linux_arm]
         build_type: [Debug, Release]
         cc: [gcc, clang]
     env:
       CC: ${{matrix.cc}}
       STATIC_ANALYSIS: ON
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: .github/workflows/sudo.sh .github/workflows/install_dependencies.sh "${STATIC_ANALYSIS}"
       - run: .github/workflows/build.sh -DCMAKE_BUILD_TYPE="${{matrix.build_type}}" -DSTATIC_ANALYSIS="${STATIC_ANALYSIS}"
 
@@ -38,7 +38,7 @@ jobs:
     env:
       STATIC_ANALYSIS: ON
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: .github/workflows/build.bat "${{matrix.build_type}}" -DSTATIC_ANALYSIS="$env:STATIC_ANALYSIS"
   
   test-nix-asan:
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{matrix.runner}}
     strategy:
       matrix:
-        runner: [ubuntu-latest, ubuntu-20.04, macos-latest, linux_arm]
+        runner: [ubuntu-latest, ubuntu-22.04, macos-latest, linux_arm]
         build_type: [Debug, Release]
         cc: [gcc, clang]
         avoid_packets_duplication: [ON, OFF]
@@ -55,7 +55,7 @@ jobs:
       CC: ${{matrix.cc}}
       STATIC_ANALYSIS: OFF
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: .github/workflows/sudo.sh .github/workflows/install_dependencies.sh "${STATIC_ANALYSIS}"
       - run: .github/workflows/build.sh -DCMAKE_BUILD_TYPE="${{matrix.build_type}}" -DSTATIC_ANALYSIS="${STATIC_ANALYSIS}" -DENABLE_ASAN=ON -DAVOID_PACKETS_DUPLICATION="${{matrix.avoid_packets_duplication}}" -DVERBOSE="${{matrix.verbose}}"
       - run: .github/workflows/test.sh
@@ -75,7 +75,7 @@ jobs:
       CC: ${{matrix.cc}}
       STATIC_ANALYSIS: OFF
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: .github/workflows/sudo.sh .github/workflows/install_dependencies.sh "${STATIC_ANALYSIS}"
       - run: .github/workflows/build.sh -DCMAKE_BUILD_TYPE="${{matrix.build_type}}" -DSTATIC_ANALYSIS="${STATIC_ANALYSIS}" -DENABLE_TSAN=ON -DAVOID_PACKETS_DUPLICATION="${{matrix.avoid_packets_duplication}}" -DVERBOSE="${{matrix.verbose}}"
       - run: .github/workflows/test.sh
@@ -85,7 +85,7 @@ jobs:
     runs-on: ${{matrix.runner}}
     strategy:
       matrix:
-        runner: [ubuntu-latest, ubuntu-20.04]
+        runner: [ubuntu-latest, ubuntu-22.04]
         build_type: [Debug, Release]
         cc: [clang]
         avoid_packets_duplication: [ON, OFF]
@@ -94,7 +94,7 @@ jobs:
       CC: ${{matrix.cc}}
       STATIC_ANALYSIS: OFF
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: .github/workflows/sudo.sh .github/workflows/install_dependencies.sh "${STATIC_ANALYSIS}"
       - run: .github/workflows/build.sh -DCMAKE_BUILD_TYPE="${{matrix.build_type}}" -DSTATIC_ANALYSIS="${STATIC_ANALYSIS}" -DENABLE_MSAN=ON -DAVOID_PACKETS_DUPLICATION="${{matrix.avoid_packets_duplication}}" -DVERBOSE="${{matrix.verbose}}"
       - run: .github/workflows/test.sh
@@ -111,7 +111,7 @@ jobs:
     env:
       STATIC_ANALYSIS: OFF
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: .github/workflows/build.bat "${{matrix.build_type}}" -DSTATIC_ANALYSIS="$env:STATIC_ANALYSIS" -DAVOID_PACKETS_DUPLICATION="${{matrix.avoid_packets_duplication}}" -DVERBOSE="${{matrix.verbose}}"
       - run: .github/workflows/test.bat "${{matrix.build_type}}"
 
@@ -128,12 +128,12 @@ jobs:
     env:
       CC: ${{matrix.cc}}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: .github/workflows/sudo.sh .github/workflows/install_dependencies.sh OFF ON
       - run: .github/workflows/build.sh -DCMAKE_BUILD_TYPE="${{matrix.build_type}}" -DENABLE_COVERAGE=ON -DAVOID_PACKETS_DUPLICATION="${{matrix.avoid_packets_duplication}}" -DVERBOSE="${{matrix.verbose}}"
       - run: .github/workflows/test.sh
       - run: .github/workflows/coverage.sh
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: code_coverage_report

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,15 +224,13 @@ if(ENABLE_COVERAGE)
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")
       if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
         message("Enabling code coverage checking")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-update=atomic")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage -fprofile-update=atomic")
 
         add_custom_target(
           code_coverage
           COMMAND
-          lcov -c -d "${CMAKE_BINARY_DIR}" -o "${CMAKE_BINARY_DIR}/lcov.info"
-          --exclude '/usr/include/*' --exclude '/usr/lib/*' --exclude
-          '/usr/local/*'
+          lcov -c -d "${CMAKE_BINARY_DIR}" -o "${CMAKE_BINARY_DIR}/lcov.info" --exclude '/usr/*'
           COMMAND
           genhtml "${CMAKE_BINARY_DIR}/lcov.info" -o
           "${CMAKE_BINARY_DIR}/code_coverage_report" >

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Optionally, a number of CMake arguments can be specified when configuring the li
     /**
     * @brief Enables sockets operations - to be called once prior to any other API calls
     *
-    * @return 0 if successfull, non-zero error code otherwise
+    * @return 0 if successful, non-zero error code otherwise
     * @note Required in Windows, unless WSAStartup is called somewhere else, can be omitted in other platforms
     */
     int32_t status = provizio_sockets_initialize();
@@ -874,11 +874,13 @@ Now you can retrive the point clouds (and their appropriate points) accumulated 
 ### Changing Radar Ranges
 
 Provizio radars can operate in various range modes, such as short, medium, long, ultra long and hyper long ranges.
-Current radar ranges are specified in `provizio_radar_point_cloud`, you can change them using `provizio_set_radar_range`:
+Current radar ranges are specified in `provizio_radar_point_cloud`, you can change them using `provizio_set_radar_range`
+and `provizio_set_radar_range_with_timeout`:
 
 ```C
 /**
- * @brief Makes a radar (or all radars) change a range
+ * @brief Makes a radar (or all radars) change a range with a default timeout =
+ * PROVIZIO__RADAR_API_SET_RANGE_DEFAULT_TIMEOUT
  *
  * @param radar_position_id Either one of provizio_radar_position enum values or a custom position id. Can also be
  * provizio_radar_position_any to set for all radars
@@ -887,9 +889,58 @@ Current radar ranges are specified in `provizio_radar_point_cloud`, you can chan
  * (if 0)
  * @param ipv4_address IP address to send change range message, in the standard IPv4 dotted decimal notation. By default
  * = "255.255.255.255" - broadcast (if NULL)
+ * @param out_actual_radar_range If not NULL, actual radar range after the operation will be stored here if received
+ * from the radar (will be provizio_radar_range_unknown otherwise)
+ * @return 0 if set successfully, PROVIZIO_E_TIMEOUT if timed out, other error value if failed for another reason
+ */
+PROVIZIO__EXTERN_C int32_t provizio_set_radar_range(provizio_radar_position radar_position_id,
+                                                    provizio_radar_range range, uint16_t udp_port,
+                                                    const char *ipv4_address,
+                                                    provizio_radar_range *out_actual_radar_range);
+```
+
+```C
+/**
+ * @brief Makes a radar (or all radars) change a range with a custom timeout
+ *
+ * @param radar_position_id Either one of provizio_radar_position enum values or a custom position id. Can also be
+ * provizio_radar_position_any to set for all radars
+ * @param range Target range to set
+ * @param udp_port UDP port to send change range message, by default = PROVIZIO__RADAR_API_SET_RANGE_DEFAULT_PORT
+ * (if 0)
+ * @param ipv4_address IP address to send change range message, in the standard IPv4 dotted decimal notation. By default
+ * = "255.255.255.255" - broadcast (if NULL)
+ * @param out_actual_radar_range If not NULL, actual radar range after the operation will be stored here if received
+ * from the radar (will be provizio_radar_range_unknown otherwise)
+ * @param timeout_ns The operation timeout (nanoseconds)
+ * @return 0 if set successfully, PROVIZIO_E_TIMEOUT if timed out, other error value if failed for another reason
+ */
+PROVIZIO__EXTERN_C int32_t provizio_set_radar_range_with_timeout(provizio_radar_position radar_position_id,
+                                                                 provizio_radar_range range, uint16_t udp_port,
+                                                                 const char *ipv4_address,
+                                                                 provizio_radar_range *out_actual_radar_range,
+                                                                 uint64_t timeout_ns);
+```
+
+You can also request the current radar range (instead of waiting for a point cloud):
+
+```C
+/**
+ * @brief Requests the current range a radar operates
+ *
+ * @param radar_position_id Either one of provizio_radar_position enum values or a custom position id. Can also be
+ * provizio_radar_position_any to request from any radar (assumes a single Provizio radar in the network)
+ * @param udp_port UDP port to send the request message, by default = PROVIZIO__RADAR_API_REQUEST_RANGE_DEFAULT_PORT
+ * (if 0)
+ * @param ipv4_address IP address to send request range message, in the standard IPv4 dotted decimal notation. By
+ * default = "255.255.255.255" - broadcast (if NULL)
+ * @param out_current_radar_range Current radar range is stored here if successful (will be provizio_radar_range_unknown
+ * otherwise)
  * @return 0 if received successfully, PROVIZIO_E_TIMEOUT if timed out, other error value if failed for another reason
  */
-int32_t status = provizio_set_radar_range(radar_position_id, range, udp_port, ipv4_address);
+PROVIZIO__EXTERN_C int32_t provizio_request_current_range(provizio_radar_position radar_position_id, uint16_t udp_port,
+                                                          const char *ipv4_address,
+                                                          provizio_radar_range *out_current_radar_range);
 ```
 
 ### Shutting Down
@@ -903,7 +954,7 @@ When you finished with the API, it has to be properly shut down.
     * @brief Closes a previously connected radar API (either a single or multiple radars on the same port)
     *
     * @param connection A previously connected provizio_radar_api_connection
-    * @return 0 if successfull, error code otherwise
+    * @return 0 if successful, error code otherwise
     */
     int32_t status = provizio_close_radars_connection(&connection);
     ```
@@ -916,7 +967,7 @@ When you finished with the API, it has to be properly shut down.
     /**
     * @brief Terminates sockets operations - to be called once after all the other API calls
     *
-    * @return 0 if successfull, non-zero error code otherwise
+    * @return 0 if successful, non-zero error code otherwise
     * @note Required in Windows, unless WSACleanup is called somewhere else, can be omitted in other platforms
     */
     int32_t status = provizio_sockets_deinitialize();
@@ -954,7 +1005,7 @@ Each packet has the following structure (all fields use network bytes order when
 | point_0: y_meters                                     | 4                                    | float     | Radar-relative Y (left) position of the point in meters                                                                         |
 | point_0: z_meters                                     | 4                                    | float     | Radar-relative Z (up) position of the point in meters                                                                           |
 | point_0: radar_relative_radial velocity_m_s           | 4                                    | float     | Radar-relative radial velocity of the point in meters per second                                                                |
-| point_0: signal_to_noise_ratio                        | 4                                    | float     | Signal-to-noise ratio (unitless)                                                                                                |
+| point_0: signal_to_noise_ratio                        | 4                                    | float     | Signal-to-noise ratio (dB)                                                                                                |
 | point_0: ground_relative_radial velocity_m_s          | 4                                    | float     | Ground-relative radial velocity of the point in meters per second                                                               |
 | point_1: ...                                          |                                      |           |                                                                                                                                 |
 | ...                                                   |                                      |           |                                                                                                                                 |
@@ -963,25 +1014,31 @@ Each packet has the following structure (all fields use network bytes order when
 ### Radar Ranges
 
 Setting radar ranges is done via sending UDP packets to an appropriate port of a radar (or all radars in the local
-network), default UDP port number: 7770. The radar sends back an acknowledgement packet.
+network), default UDP port number: 7770. The radar sends back an acknowledgement packet immediately and later a response
+packet when the operation is complete successfully or not.
+
+***Note***: In case current_radar_range == requested_radar_range or error_code != 0 in acknowledgement the response is
+**not** sent as in either of the cases the radar range is not updated.
 
 Set range packet:
 
 | Field                          | Size (bytes)                         | Data Type | Description                                                                                                                     |
 | ------------------------------ | ------------------------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | packet_type                    | 2                                    | uint16_t  | Always = 2, can't change even on protocol updates                                                                               |
-| protocol_version               | 2                                    | uint16_t  | Currently = 1, to be incremented on any protocol changes (used for backward compatibility)                                      |
+| protocol_version               | 2                                    | uint16_t  | Currently = 2, to be incremented on any protocol changes (used for backward compatibility)                                      |
 | radar_position_id              | 2                                    | uint16_t  | Either one of provizio_radar_position enum values or a custom position id                                                       |
 | radar_range                    | 2                                    | uint16_t  | One of provizio_radar_range enum values                                                                                         |
 | **Total**                      | **8**                                |           |                                                                                                                                 |
 
-Acknowledgement packet:
+Acknowledgement/Response packet:
 
 | Field                          | Size (bytes)                         | Data Type | Description                                                                                                                     |
 | ------------------------------ | ------------------------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| packet_type                    | 2                                    | uint16_t  | Always = 3, can't change even on protocol updates                                                                               |
-| protocol_version               | 2                                    | uint16_t  | Currently = 1, to be incremented on any protocol changes (used for backward compatibility)                                      |
+| packet_type                    | 2                                    | uint16_t  | Always = 3 for acknowledgement, = 4 for response, can't change even on protocol updates                                         |
+| protocol_version               | 2                                    | uint16_t  | Currently = 2, to be incremented on any protocol changes (used for backward compatibility)                                      |
 | radar_position_id              | 2                                    | uint16_t  | Either one of provizio_radar_position enum values or a custom position id                                                       |
 | requested_radar_range          | 2                                    | uint16_t  | One of provizio_radar_range enum values                                                                                         |
-| error_code                     | 4                                    | int32_t   | 0 for success, PROVIZIO_E_NOT_PERMITTED if the range is not supported                                                           |
-| **Total**                      | **12**                               |           |                                                                                                                                 |
+| current_radar_range            | 2                                    | uint16_t  | One of provizio_radar_range enum values                                                                                         |
+| reserved                       | 2                                    | uint16_t  | Reserved for future use and better memory alignment                                                                             |
+| error_code                     | 4                                    | int32_t   | 0 for success, PROVIZIO_E_NOT_SUPPORTED=95 if the range is not supported                                                        |
+| **Total**                      | **16**                               |           |                                                                                                                                 |

--- a/include/provizio/radar_api/common.h
+++ b/include/provizio/radar_api/common.h
@@ -21,6 +21,7 @@
 #define PROVIZIO__RADAR_API_POINT_CLOUD_PACKET_TYPE ((uint16_t)1)
 #define PROVIZIO__RADAR_API_SET_RANGE_PACKET_TYPE ((uint16_t)2)
 #define PROVIZIO__RADAR_API_SET_RANGE_ACKNOWLEDGEMENT_PACKET_TYPE ((uint16_t)3)
+#define PROVIZIO__RADAR_API_SET_RANGE_RESPONSE_PACKET_TYPE ((uint16_t)4)
 
 // Use packed structs intended to be sent for binary compatibility across all CPUs
 #pragma pack(push, 1)

--- a/include/provizio/radar_api/core.h
+++ b/include/provizio/radar_api/core.h
@@ -23,8 +23,10 @@
 #include "provizio/socket.h"
 #include "provizio/util.h"
 
-#define PROVIZIO__RADAR_API_DEFAULT_PORT ((uint16_t)7769)
-#define PROVIZIO__RADAR_API_SET_RANGE_DEFAULT_PORT ((uint16_t)7770)
+#define PROVIZIO__RADAR_API_DEFAULT_PORT ((uint16_t)7769U)
+#define PROVIZIO__RADAR_API_SET_RANGE_DEFAULT_PORT ((uint16_t)7770U)
+#define PROVIZIO__RADAR_API_SET_RANGE_DEFAULT_TIMEOUT ((uint64_t)30000000000ULL)
+#define PROVIZIO__RADAR_API_REQUEST_RANGE_DEFAULT_PORT ((uint16_t)7770U) // Uses "set range to unknown" to request it
 
 /**
  * @brief A single Provizio Radar API connection handle on a single UDP port
@@ -91,13 +93,14 @@ PROVIZIO__EXTERN_C int32_t provizio_radar_api_receive_packet(provizio_radar_api_
  * @brief Closes a previously connected radar API (either a single or multiple radars on the same port)
  *
  * @param connection A previously connected provizio_radar_api_connection
- * @return 0 if successfull, error code otherwise
+ * @return 0 if successful, error code otherwise
  */
 PROVIZIO__EXTERN_C int32_t provizio_close_radars_connection(provizio_radar_api_connection *connection);
 #define provizio_close_radar_connection provizio_close_radars_connection
 
 /**
- * @brief Makes a radar (or all radars) change a range
+ * @brief Makes a radar (or all radars) change a range with a default timeout =
+ * PROVIZIO__RADAR_API_SET_RANGE_DEFAULT_TIMEOUT
  *
  * @param radar_position_id Either one of provizio_radar_position enum values or a custom position id. Can also be
  * provizio_radar_position_any to set for all radars
@@ -106,10 +109,51 @@ PROVIZIO__EXTERN_C int32_t provizio_close_radars_connection(provizio_radar_api_c
  * (if 0)
  * @param ipv4_address IP address to send change range message, in the standard IPv4 dotted decimal notation. By default
  * = "255.255.255.255" - broadcast (if NULL)
- * @return 0 if received successfully, PROVIZIO_E_TIMEOUT if timed out, other error value if failed for another reason
+ * @param out_actual_radar_range If not NULL, actual radar range after the operation will be stored here if received
+ * from the radar (will be provizio_radar_range_unknown otherwise)
+ * @return 0 if set successfully, PROVIZIO_E_TIMEOUT if timed out, other error value if failed for another reason
  */
 PROVIZIO__EXTERN_C int32_t provizio_set_radar_range(provizio_radar_position radar_position_id,
                                                     provizio_radar_range range, uint16_t udp_port,
-                                                    const char *ipv4_address);
+                                                    const char *ipv4_address,
+                                                    provizio_radar_range *out_actual_radar_range);
+
+/**
+ * @brief Makes a radar (or all radars) change a range with a custom timeout
+ *
+ * @param radar_position_id Either one of provizio_radar_position enum values or a custom position id. Can also be
+ * provizio_radar_position_any to set for all radars
+ * @param range Target range to set
+ * @param udp_port UDP port to send change range message, by default = PROVIZIO__RADAR_API_SET_RANGE_DEFAULT_PORT
+ * (if 0)
+ * @param ipv4_address IP address to send change range message, in the standard IPv4 dotted decimal notation. By default
+ * = "255.255.255.255" - broadcast (if NULL)
+ * @param out_actual_radar_range If not NULL, actual radar range after the operation will be stored here if received
+ * from the radar (will be provizio_radar_range_unknown otherwise)
+ * @param timeout_ns The operation timeout (nanoseconds)
+ * @return 0 if set successfully, PROVIZIO_E_TIMEOUT if timed out, other error value if failed for another reason
+ */
+PROVIZIO__EXTERN_C int32_t provizio_set_radar_range_with_timeout(provizio_radar_position radar_position_id,
+                                                                 provizio_radar_range range, uint16_t udp_port,
+                                                                 const char *ipv4_address,
+                                                                 provizio_radar_range *out_actual_radar_range,
+                                                                 uint64_t timeout_ns);
+
+/**
+ * @brief Requests the current range a radar operates
+ *
+ * @param radar_position_id Either one of provizio_radar_position enum values or a custom position id. Can also be
+ * provizio_radar_position_any to request from any radar (assumes a single Provizio radar in the network)
+ * @param udp_port UDP port to send the request message, by default = PROVIZIO__RADAR_API_REQUEST_RANGE_DEFAULT_PORT
+ * (if 0)
+ * @param ipv4_address IP address to send request range message, in the standard IPv4 dotted decimal notation. By
+ * default = "255.255.255.255" - broadcast (if NULL)
+ * @param out_current_radar_range Current radar range is stored here if successful (will be provizio_radar_range_unknown
+ * otherwise)
+ * @return 0 if received successfully, PROVIZIO_E_TIMEOUT if timed out, other error value if failed for another reason
+ */
+PROVIZIO__EXTERN_C int32_t provizio_request_current_range(provizio_radar_position radar_position_id, uint16_t udp_port,
+                                                          const char *ipv4_address,
+                                                          provizio_radar_range *out_current_radar_range);
 
 #endif // PROVIZIO_RADAR_API_CORE

--- a/include/provizio/radar_api/errno.h
+++ b/include/provizio/radar_api/errno.h
@@ -17,11 +17,12 @@
 
 #include <errno.h>
 
-#define PROVIZIO_E_TIMEOUT EAGAIN        // Operation timed out
-#define PROVIZIO_E_SKIPPED ERANGE        // Packet skipped and ignored
-#define PROVIZIO_E_OUT_OF_CONTEXTS EBUSY // Not enough contexts
-#define PROVIZIO_E_PROTOCOL EPROTO       // Protocol error
-#define PROVIZIO_E_ARGUMENT EINVAL       // Invalid argument
-#define PROVIZIO_E_NOT_PERMITTED EPERM   // Operation not permitted
+#define PROVIZIO_E_TIMEOUT EAGAIN           // Operation timed out
+#define PROVIZIO_E_SKIPPED ERANGE           // Packet skipped and ignored
+#define PROVIZIO_E_OUT_OF_CONTEXTS EBUSY    // Not enough contexts
+#define PROVIZIO_E_PROTOCOL EPROTO          // Protocol error
+#define PROVIZIO_E_ARGUMENT EINVAL          // Invalid argument
+#define PROVIZIO_E_CANCELED ECANCELED       // Operation Canceled
+#define PROVIZIO_E_NOT_SUPPORTED EOPNOTSUPP // Operation not supported
 
 #endif // PROVIZIO_RADAR_API_ERRNO

--- a/include/provizio/radar_api/radar_ranges.h
+++ b/include/provizio/radar_api/radar_ranges.h
@@ -19,7 +19,7 @@
 #include "provizio/radar_api/radar_position.h"
 
 // To be incremented on any breaking protocol changes (used for backward compatibility)
-#define PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION ((uint16_t)1)
+#define PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION ((uint16_t)2)
 
 // Use packed structs intended to be sent for binary compatibility across all CPUs
 #pragma pack(push, 1)
@@ -63,14 +63,16 @@ typedef struct provizio_set_radar_range_packet
  * @see provizio_set_protocol_field_uint32_t
  * @see provizio_get_protocol_field_uint32_t
  */
-typedef struct provizio_set_radar_range_acknowledgement_packet
+typedef struct provizio_set_radar_range_response_packet
 {
     provizio_radar_api_protocol_header protocol_header;
 
     uint16_t radar_position_id;     // Either one of provizio_radar_position enum values or a custom position id
     uint16_t requested_radar_range; // One of provizio_radar_range enum values
-    int32_t error_code;             // 0 for success, PROVIZIO_E_NOT_PERMITTED if the range is not supported
-} provizio_set_radar_range_acknowledgement_packet;
+    uint16_t current_radar_range;   // One of provizio_radar_range enum values
+    uint16_t reserved;              // Reserved for future use and better memory alignment |
+    int32_t error_code;             // 0 for success, PROVIZIO_E_NOT_SUPPORTED if the range is not supported
+} provizio_set_radar_range_response_packet;
 
 // Reset alignment settings
 #pragma pack(pop)
@@ -83,16 +85,18 @@ static_assert(offsetof(provizio_set_radar_range_packet, radar_position_id) == 4,
 static_assert(offsetof(provizio_set_radar_range_packet, radar_range) == 6,
               "Unexpected position of radar_range in provizio_set_radar_range_packet");
 static_assert(sizeof(provizio_set_radar_range_packet) == 8, "Unexpected size of provizio_set_radar_range_packet");
-static_assert(offsetof(provizio_set_radar_range_acknowledgement_packet, protocol_header) == 0,
-              "Unexpected position of protocol_header in provizio_set_radar_range_acknowledgement_packet");
-static_assert(offsetof(provizio_set_radar_range_acknowledgement_packet, radar_position_id) == 4,
-              "Unexpected position of radar_position_id in provizio_set_radar_range_acknowledgement_packet");
-static_assert(offsetof(provizio_set_radar_range_acknowledgement_packet, requested_radar_range) == 6,
-              "Unexpected position of requested_radar_range in provizio_set_radar_range_acknowledgement_packet");
-static_assert(offsetof(provizio_set_radar_range_acknowledgement_packet, error_code) == 8,
-              "Unexpected position of error_code in provizio_set_radar_range_acknowledgement_packet");
-static_assert(sizeof(provizio_set_radar_range_acknowledgement_packet) == 12,
-              "Unexpected size of provizio_set_radar_range_acknowledgement_packet");
+static_assert(offsetof(provizio_set_radar_range_response_packet, protocol_header) == 0,
+              "Unexpected position of protocol_header in provizio_set_radar_range_response_packet");
+static_assert(offsetof(provizio_set_radar_range_response_packet, radar_position_id) == 4,
+              "Unexpected position of radar_position_id in provizio_set_radar_range_response_packet");
+static_assert(offsetof(provizio_set_radar_range_response_packet, requested_radar_range) == 6,
+              "Unexpected position of requested_radar_range in provizio_set_radar_range_response_packet");
+static_assert(offsetof(provizio_set_radar_range_response_packet, current_radar_range) == 8,
+              "Unexpected position of current_radar_range in provizio_set_radar_range_response_packet");
+static_assert(offsetof(provizio_set_radar_range_response_packet, error_code) == 12,
+              "Unexpected position of error_code in provizio_set_radar_range_response_packet");
+static_assert(sizeof(provizio_set_radar_range_response_packet) == 16,
+              "Unexpected size of provizio_set_radar_range_response_packet");
 #endif // defined(__cplusplus) && __cplusplus >= 201103L
 
 #endif // PROVIZIO_RADAR_API_RADAR_RANGES

--- a/include/provizio/socket.h
+++ b/include/provizio/socket.h
@@ -45,7 +45,7 @@
 /**
  * @brief Enables sockets operations - to be called once prior to any other API calls
  *
- * @return 0 if successfull, non-zero error code otherwise
+ * @return 0 if successful, non-zero error code otherwise
  * @note Required in Windows, unless WSAStartup is called somewhere else, can be omitted in other platforms
  */
 PROVIZIO__EXTERN_C int32_t provizio_sockets_initialize(void);
@@ -53,7 +53,7 @@ PROVIZIO__EXTERN_C int32_t provizio_sockets_initialize(void);
 /**
  * @brief Terminates sockets operations - to be called once after all the other API calls
  *
- * @return 0 if successfull, non-zero error code otherwise
+ * @return 0 if successful, non-zero error code otherwise
  * @note Required in Windows, unless WSACleanup is called somewhere else, can be omitted in other platforms
  */
 PROVIZIO__EXTERN_C int32_t provizio_sockets_deinitialize(void);
@@ -63,14 +63,15 @@ PROVIZIO__EXTERN_C int32_t provizio_sockets_deinitialize(void);
  *
  * @param sock `socket`-returned socket object
  * @return nonzero if valid, 0 otherwise
+ * @note Made a macro so clang-tidy can see it and doesn't produce false-positive warnings (treated as errors)
  */
-PROVIZIO__EXTERN_C int32_t provizio_socket_valid(PROVIZIO__SOCKET sock);
+#define provizio_socket_valid(sock) ((int32_t)((sock) != PROVIZIO__INVALID_SOCKET))
 
 /**
  * @brief Closes a previously opened socket
  *
  * @param sock `socket`-returned socket object
- * @return 0 if successfull, non-zero error code otherwise
+ * @return 0 if successful, non-zero error code otherwise
  */
 PROVIZIO__EXTERN_C int32_t provizio_socket_close(PROVIZIO__SOCKET sock);
 
@@ -79,7 +80,7 @@ PROVIZIO__EXTERN_C int32_t provizio_socket_close(PROVIZIO__SOCKET sock);
  *
  * @param sock `socket`-returned socket object
  * @param timeout_ns Timeout in nanoseconds
- * @return 0 if successfull, error code otherwise
+ * @return 0 if successful, error code otherwise
  */
 PROVIZIO__EXTERN_C int32_t provizio_socket_set_recv_timeout(PROVIZIO__SOCKET sock, uint64_t timeout_ns);
 
@@ -87,7 +88,7 @@ PROVIZIO__EXTERN_C int32_t provizio_socket_set_recv_timeout(PROVIZIO__SOCKET soc
  * @brief Permits for having multiple processes in the system to receive same UDP messages
  *
  * @param sock `socket`-returned socket object
- * @return 0 if successfull, error code otherwise
+ * @return 0 if successful, error code otherwise
  */
 PROVIZIO__EXTERN_C int32_t provizio_socket_enable_address_and_port_reuse(PROVIZIO__SOCKET sock);
 

--- a/src/core.c
+++ b/src/core.c
@@ -202,18 +202,33 @@ int32_t provizio_close_radars_connection(provizio_radar_api_connection *connecti
 }
 
 int32_t provizio_set_radar_range(provizio_radar_position radar_position_id, provizio_radar_range range,
-                                 uint16_t udp_port, const char *ipv4_address)
+                                 uint16_t udp_port, const char *ipv4_address,
+                                 provizio_radar_range *out_actual_radar_range)
+{
+    return provizio_set_radar_range_with_timeout(radar_position_id, range, udp_port, ipv4_address,
+                                                 out_actual_radar_range, PROVIZIO__RADAR_API_SET_RANGE_DEFAULT_TIMEOUT);
+}
+
+int32_t provizio_set_radar_range_with_timeout(provizio_radar_position radar_position_id, provizio_radar_range range,
+                                              uint16_t udp_port, const char *ipv4_address,
+                                              provizio_radar_range *out_actual_radar_range, uint64_t timeout_ns)
 {
     const char *broadcast_ipv4_address = "255.255.255.255";
     const uint64_t recv_timeout_ns = 250000000; // 0.25s
-    const int max_recv_tries = 5;
+    const int max_ack_recv_tries = 6;
 
-    provizio_verbose("provizio_set_radar_range: Setting a radar range of %d to %d at %s:%d...", (int)radar_position_id,
-                     (int)range, (ipv4_address != NULL ? ipv4_address : broadcast_ipv4_address), (int)udp_port);
+    provizio_verbose("provizio_set_radar_range_with_timeout: Setting a radar range of %d to %d at %s:%d...",
+                     (int)radar_position_id, (int)range, (ipv4_address != NULL ? ipv4_address : broadcast_ipv4_address),
+                     (int)udp_port);
 
-    if (range == provizio_radar_range_unknown)
+    if (out_actual_radar_range != NULL)
     {
-        provizio_error("provizio_set_radar_range: provizio_radar_range_unknown is not a valid range option!");
+        *out_actual_radar_range = provizio_radar_range_unknown;
+    }
+
+    if (timeout_ns / recv_timeout_ns + max_ack_recv_tries > INT32_MAX)
+    {
+        provizio_error("provizio_set_radar_range_with_timeout: timeout_ns is too large");
         return PROVIZIO_E_ARGUMENT;
     }
 
@@ -225,7 +240,7 @@ int32_t provizio_set_radar_range(provizio_radar_position radar_position_id, prov
     {
         // LCOV_EXCL_START: Can't be unit-tested as it depends on the state of the OS
         status = (int32_t)errno;
-        provizio_error("provizio_set_radar_range: Failed to create a UDP socket!");
+        provizio_error("provizio_set_radar_range_with_timeout: Failed to create a UDP socket!");
         return status != 0 ? status : (int32_t)-1;
         // LCOV_EXCL_STOP
     }
@@ -234,7 +249,7 @@ int32_t provizio_set_radar_range(provizio_radar_position radar_position_id, prov
     if (status != 0)
     {
         // LCOV_EXCL_START: Can't be unit-tested as it depends on the state of the OS
-        provizio_error("provizio_set_radar_range: Failed to set recv timeout!");
+        provizio_error("provizio_set_radar_range_with_timeout: Failed to set recv timeout!");
         provizio_socket_close(sock);
         return status;
         // LCOV_EXCL_STOP
@@ -248,7 +263,7 @@ int32_t provizio_set_radar_range(provizio_radar_position radar_position_id, prov
         if (status != 0)
         {
             // LCOV_EXCL_START: Can't be unit-tested as it depends on the state of the OS
-            provizio_error("provizio_set_radar_range: Failed to enable broadcasting!");
+            provizio_error("provizio_set_radar_range_with_timeout: Failed to enable broadcasting!");
             provizio_socket_close(sock);
             return status;
             // LCOV_EXCL_STOP
@@ -265,7 +280,7 @@ int32_t provizio_set_radar_range(provizio_radar_position radar_position_id, prov
     if (status != 0)
     {
         // LCOV_EXCL_START: Can't be unit-tested as it depends on the state of the OS
-        provizio_error("provizio_set_radar_range: Failed to bind socket");
+        provizio_error("provizio_set_radar_range_with_timeout: Failed to bind socket");
         provizio_socket_close(sock);
         return status;
         // LCOV_EXCL_STOP
@@ -288,10 +303,12 @@ int32_t provizio_set_radar_range(provizio_radar_position radar_position_id, prov
     provizio_set_protocol_field_uint16_t(&set_range_packet.radar_position_id, radar_position_id);
     provizio_set_protocol_field_uint16_t(&set_range_packet.radar_range, range);
 
-    provizio_set_radar_range_acknowledgement_packet acknowledgement_packet;
-    memset(&acknowledgement_packet, 0, sizeof(acknowledgement_packet));
+    provizio_set_radar_range_response_packet response_packet;
+    memset(&response_packet, 0, sizeof(response_packet));
 
-    int recv_tries = max_recv_tries + 1;
+    // Send the request and wait for an acknowledgement packet
+    int8_t acknowledgement_received = 0;
+    int recv_tries = max_ack_recv_tries;
     do
     {
         status = (int32_t)sendto(sock, (const char *)&set_range_packet, // NOLINT
@@ -301,51 +318,66 @@ int32_t provizio_set_radar_range(provizio_radar_position radar_position_id, prov
         if (status < 0)
         {
             // LCOV_EXCL_START: Can't be unit-tested as it depends on the state of the OS
-            provizio_error("provizio_set_radar_range: Failed to send provizio_set_radar_range_packet");
+            provizio_error("provizio_set_radar_range_with_timeout: Failed to send provizio_set_radar_range_packet");
             provizio_socket_close(sock);
             return status;
             // LCOV_EXCL_STOP
         }
 
         // Receive an acknowledgement
-        status = (int32_t)recv(sock, (char *)&acknowledgement_packet, sizeof(acknowledgement_packet), 0);
-        if (status == sizeof(acknowledgement_packet))
+        status = (int32_t)recv(sock, (char *)&response_packet, sizeof(response_packet), 0);
+        uint16_t packet_type = 0;
+        if (status >= (int32_t)sizeof(provizio_radar_api_protocol_header))
         {
-            if (provizio_get_protocol_field_uint16_t(&acknowledgement_packet.protocol_header.packet_type) !=
-                PROVIZIO__RADAR_API_SET_RANGE_ACKNOWLEDGEMENT_PACKET_TYPE)
+            packet_type = provizio_get_protocol_field_uint16_t(&response_packet.protocol_header.packet_type);
+            if (packet_type != PROVIZIO__RADAR_API_SET_RANGE_ACKNOWLEDGEMENT_PACKET_TYPE &&
+                packet_type != PROVIZIO__RADAR_API_SET_RANGE_RESPONSE_PACKET_TYPE)
             {
-                provizio_error("provizio_set_radar_range: Invalid acknowledgement packet type received");
+                provizio_error("provizio_set_radar_range_with_timeout: Invalid acknowledgement packet type received");
+                provizio_socket_close(sock);
                 return PROVIZIO_E_PROTOCOL;
             }
 
-            if (provizio_get_protocol_field_uint16_t(&acknowledgement_packet.protocol_header.protocol_version) !=
+            if (provizio_get_protocol_field_uint16_t(&response_packet.protocol_header.protocol_version) !=
                 PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION)
             {
-                provizio_error("provizio_set_radar_range: Incompatible protocol version");
+                provizio_error("provizio_set_radar_range_with_timeout: Incompatible protocol version");
+                provizio_socket_close(sock);
                 return PROVIZIO_E_PROTOCOL;
             }
+        }
 
-            if ((radar_position_id != provizio_radar_position_any &&
-                 provizio_get_protocol_field_uint16_t(&acknowledgement_packet.radar_position_id) !=
-                     radar_position_id) ||
-                provizio_get_protocol_field_uint16_t(&acknowledgement_packet.requested_radar_range) != range)
+        if (status == sizeof(response_packet))
+        {
+            if (packet_type != PROVIZIO__RADAR_API_SET_RANGE_ACKNOWLEDGEMENT_PACKET_TYPE ||
+                (radar_position_id != provizio_radar_position_any &&
+                 provizio_get_protocol_field_uint16_t(&response_packet.radar_position_id) != radar_position_id) ||
+                provizio_get_protocol_field_uint16_t(&response_packet.requested_radar_range) != range)
             {
-                // Correct acknowledgement packet, but from a previous provizio_set_radar_range request: keep waiting
-                // for the correct one
-                provizio_verbose("provizio_set_radar_range: Attempt timeout");
+                // Correct packet format, but from a previous provizio_set_radar_range request: keep
+                // waiting for the correct one
+                provizio_verbose("provizio_set_radar_range_with_timeout: Attempt timeout");
                 status = PROVIZIO_E_TIMEOUT;
             }
             else
             {
                 // Correct acknowledgement
-                status = (int32_t)provizio_get_protocol_field_uint32_t((uint32_t *)&acknowledgement_packet.error_code);
+                acknowledgement_received = 1;
+
+                if (out_actual_radar_range != NULL)
+                {
+                    *out_actual_radar_range =
+                        provizio_get_protocol_field_uint16_t(&response_packet.current_radar_range);
+                }
+
+                status = (int32_t)provizio_get_protocol_field_uint32_t((uint32_t *)&response_packet.error_code);
                 if (status == 0)
                 {
-                    provizio_verbose("provizio_set_radar_range: Received acknowledgement - Success");
+                    provizio_verbose("provizio_set_radar_range_with_timeout: Received acknowledgement - Success");
                 }
                 else
                 {
-                    provizio_verbose("provizio_set_radar_range: Received acknowledgement - Failure");
+                    provizio_verbose("provizio_set_radar_range_with_timeout: Received acknowledgement - Failure");
                 }
             }
         }
@@ -354,23 +386,111 @@ int32_t provizio_set_radar_range(provizio_radar_position radar_position_id, prov
             status = errno;
             if (status == 0 || status == (int32_t)EWOULDBLOCK)
             {
-                provizio_verbose("provizio_set_radar_range: Timed out");
+                provizio_verbose("provizio_set_radar_range_with_timeout: Attempt timeout");
                 status = PROVIZIO_E_TIMEOUT;
             }
         }
-    } while (status == PROVIZIO_E_TIMEOUT && --recv_tries != 0);
+    } while (status == PROVIZIO_E_TIMEOUT && --recv_tries > 0);
+
+    // Waiting for the response on operation completion now, unless acknowledgment phase failed or the range is already
+    // as requested
+    if (status == 0 && provizio_get_protocol_field_uint16_t(&response_packet.current_radar_range) != range)
+    {
+        // Using timeout_ns and knowing how many timed out receive tries has already been done on the acknowledgement
+        // step (i.e. time already spent), calculate how many tries we still have left for receiving the response.
+        // Even if resulting value is <= 0, at least a single receive attempt will be done by design thanks to do..while
+        recv_tries = (int)(timeout_ns / recv_timeout_ns) - (max_ack_recv_tries - recv_tries);
+
+        do
+        {
+            // Receive a response
+            status = (int32_t)recv(sock, (char *)&response_packet, sizeof(response_packet), 0);
+            uint16_t packet_type = 0;
+            if (status >= (int32_t)sizeof(provizio_radar_api_protocol_header))
+            {
+                packet_type = provizio_get_protocol_field_uint16_t(&response_packet.protocol_header.packet_type);
+                if (packet_type != PROVIZIO__RADAR_API_SET_RANGE_ACKNOWLEDGEMENT_PACKET_TYPE &&
+                    packet_type != PROVIZIO__RADAR_API_SET_RANGE_RESPONSE_PACKET_TYPE)
+                {
+                    provizio_error("provizio_set_radar_range_with_timeout: Invalid response packet type received");
+                    provizio_socket_close(sock);
+                    return PROVIZIO_E_PROTOCOL;
+                }
+
+                if (provizio_get_protocol_field_uint16_t(&response_packet.protocol_header.protocol_version) !=
+                    PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION)
+                {
+                    provizio_error("provizio_set_radar_range_with_timeout: Incompatible protocol version");
+                    provizio_socket_close(sock);
+                    return PROVIZIO_E_PROTOCOL;
+                }
+            }
+
+            if (status == sizeof(response_packet))
+            {
+                if (packet_type != PROVIZIO__RADAR_API_SET_RANGE_RESPONSE_PACKET_TYPE ||
+                    (radar_position_id != provizio_radar_position_any &&
+                     provizio_get_protocol_field_uint16_t(&response_packet.radar_position_id) != radar_position_id) ||
+                    provizio_get_protocol_field_uint16_t(&response_packet.requested_radar_range) != range)
+                {
+                    // Correct packet format, but from a previous provizio_set_radar_range request: keep
+                    // waiting for the correct one
+                    provizio_verbose("provizio_set_radar_range_with_timeout: Attempt timeout");
+                    status = PROVIZIO_E_TIMEOUT;
+                }
+                else
+                {
+                    // Correct response
+                    if (out_actual_radar_range != NULL)
+                    {
+                        *out_actual_radar_range =
+                            provizio_get_protocol_field_uint16_t(&response_packet.current_radar_range);
+                    }
+
+                    status = (int32_t)provizio_get_protocol_field_uint32_t((uint32_t *)&response_packet.error_code);
+                    if (status == 0)
+                    {
+                        provizio_verbose("provizio_set_radar_range_with_timeout: Received acknowledgement - Success");
+                    }
+                    else
+                    {
+                        provizio_verbose("provizio_set_radar_range_with_timeout: Received acknowledgement - Failure");
+                    }
+                }
+            }
+            else
+            {
+                status = errno;
+                if (status == 0 || status == (int32_t)EWOULDBLOCK)
+                {
+                    provizio_verbose("provizio_set_radar_range_with_timeout: Attempt timeout");
+                    status = PROVIZIO_E_TIMEOUT;
+                }
+            }
+        } while (status == PROVIZIO_E_TIMEOUT && --recv_tries > 0);
+    }
 
     if (status != 0)
     {
         if (status == PROVIZIO_E_TIMEOUT)
         {
-            provizio_error("provizio_set_radar_range: No acknowledgement received, likely due to a connection issue");
+            if (!acknowledgement_received)
+            {
+                provizio_error("provizio_set_radar_range_with_timeout: No acknowledgement received, likely due to a "
+                               "connection issue");
+            }
+            else
+            {
+                provizio_error(
+                    "provizio_set_radar_range_with_timeout: Received the acknowledgement but not the response");
+            }
         }
-        else
+        else if (range != provizio_radar_range_unknown) // Unknown is used for requesting current range, not an error
         {
-            provizio_error("provizio_set_radar_range: Failed to set the requested range");
+            provizio_error("provizio_set_radar_range_with_timeout: Failed to set the requested range");
         }
 
+        provizio_socket_close(sock);
         return status;
     }
 
@@ -378,12 +498,28 @@ int32_t provizio_set_radar_range(provizio_radar_position radar_position_id, prov
     if (status != 0)
     {
         // LCOV_EXCL_START: Can't be unit-tested as it depends on the state of the OS
-        provizio_error("provizio_set_radar_range: Failed to close the socket");
+        provizio_error("provizio_set_radar_range_with_timeout: Failed to close the socket");
         return status;
         // LCOV_EXCL_STOP
     }
 
-    provizio_verbose("provizio_set_radar_range: Success");
+    provizio_verbose("provizio_set_radar_range_with_timeout: Success");
 
     return 0;
+}
+
+int32_t provizio_request_current_range(provizio_radar_position radar_position_id, uint16_t udp_port,
+                                       const char *ipv4_address, provizio_radar_range *out_current_radar_range)
+{
+    if (out_current_radar_range == NULL)
+    {
+        provizio_error("provizio_request_current_range: out_current_radar_range argument can't be NULL");
+        return PROVIZIO_E_ARGUMENT;
+    }
+
+    // "Set range to provizio_radar_range_unknown" is used to detect the current range
+    *out_current_radar_range = provizio_radar_range_unknown;
+    int32_t status = provizio_set_radar_range(radar_position_id, provizio_radar_range_unknown, udp_port, ipv4_address,
+                                              out_current_radar_range);
+    return *out_current_radar_range != provizio_radar_range_unknown ? 0 : status;
 }

--- a/src/radar_point_cloud.c
+++ b/src/radar_point_cloud.c
@@ -233,7 +233,7 @@ int32_t provizio_radar_point_cloud_api_context_assign(provizio_radar_point_cloud
     }
 
     provizio_error("provizio_radar_point_cloud_api_context_assign: already assigned");
-    return PROVIZIO_E_NOT_PERMITTED;
+    return PROVIZIO_E_NOT_SUPPORTED;
 }
 
 int32_t provizio_check_radar_point_cloud_packet(provizio_radar_point_cloud_packet *packet, size_t packet_size)

--- a/src/radar_points_accumulation_filters.c
+++ b/src/radar_points_accumulation_filters.c
@@ -89,7 +89,7 @@ static float provizio_estimate_radars_forward_velocity_using_velocities_histogra
     }
 
     const float half = 0.5F;
-    return -(min_velocity + (half + (float)largest_bin) * bin_size);
+    return -(min_velocity + ((half + (float)largest_bin) * bin_size));
 }
 
 static float provizio_estimate_radars_forward_velocity(

--- a/src/radar_points_accumulation_types.c
+++ b/src/radar_points_accumulation_types.c
@@ -34,17 +34,17 @@ void provizio_quaternion_set_euler_angles(float x_rad, float y_rad, float z_rad,
     const float cos_half_z = cosf(z_rad * half);
     const float sin_half_z = sinf(z_rad * half);
 
-    out_quaternion->w = cos_half_x * cos_half_y * cos_half_z + sin_half_x * sin_half_y * sin_half_z;
-    out_quaternion->x = sin_half_x * cos_half_y * cos_half_z - cos_half_x * sin_half_y * sin_half_z;
-    out_quaternion->y = cos_half_x * sin_half_y * cos_half_z + sin_half_x * cos_half_y * sin_half_z;
-    out_quaternion->z = cos_half_x * cos_half_y * sin_half_z - sin_half_x * sin_half_y * cos_half_z;
+    out_quaternion->w = (cos_half_x * cos_half_y * cos_half_z) + (sin_half_x * sin_half_y * sin_half_z);
+    out_quaternion->x = (sin_half_x * cos_half_y * cos_half_z) - (cos_half_x * sin_half_y * sin_half_z);
+    out_quaternion->y = (cos_half_x * sin_half_y * cos_half_z) + (sin_half_x * cos_half_y * sin_half_z);
+    out_quaternion->z = (cos_half_x * cos_half_y * sin_half_z) - (sin_half_x * sin_half_y * cos_half_z);
 }
 
 uint8_t provizio_quaternion_is_valid_rotation(const provizio_quaternion *quaternion)
 {
     const float epsilon = 0.0001F;
-    const float squared_length = quaternion->w * quaternion->w + quaternion->x * quaternion->x +
-                                 quaternion->y * quaternion->y + quaternion->z * quaternion->z;
+    const float squared_length = (quaternion->w * quaternion->w) + (quaternion->x * quaternion->x) +
+                                 (quaternion->y * quaternion->y) + (quaternion->z * quaternion->z);
     return 1.0F - epsilon < squared_length && squared_length < 1.0F + epsilon;
 }
 
@@ -53,5 +53,5 @@ float provizio_enu_distance(const provizio_enu_position *position_a, const provi
     const float diff_east = position_a->east_meters - position_b->east_meters;
     const float diff_north = position_a->north_meters - position_b->north_meters;
     const float diff_up = position_a->up_meters - position_b->up_meters;
-    return sqrtf(diff_east * diff_east + diff_north * diff_north + diff_up * diff_up);
+    return sqrtf((diff_east * diff_east) + (diff_north * diff_north) + (diff_up * diff_up));
 }

--- a/src/socket.c
+++ b/src/socket.c
@@ -33,11 +33,6 @@ int32_t provizio_sockets_deinitialize(void)
 #endif
 }
 
-int32_t provizio_socket_valid(PROVIZIO__SOCKET sock)
-{
-    return (int32_t)(sock != PROVIZIO__INVALID_SOCKET);
-}
-
 int32_t provizio_socket_close(PROVIZIO__SOCKET sock)
 {
 #ifdef _WIN32

--- a/src/util.c
+++ b/src/util.c
@@ -210,8 +210,8 @@ int64_t provizio_time_interval_ns(struct timeval *time_b, struct timeval *time_a
     const int64_t nanoseconds_in_second = 1000000000LL;
     const int64_t nanoseconds_in_microsecond = 1000LL;
 
-    return ((int64_t)time_b->tv_sec - (int64_t)time_a->tv_sec) * nanoseconds_in_second +
-           ((int64_t)time_b->tv_usec - (int64_t)time_a->tv_usec) * nanoseconds_in_microsecond;
+    return (((int64_t)time_b->tv_sec - (int64_t)time_a->tv_sec) * nanoseconds_in_second) +
+           (((int64_t)time_b->tv_usec - (int64_t)time_a->tv_usec) * nanoseconds_in_microsecond);
 }
 
 float provizio_nanoseconds_to_seconds(int64_t duration_ns)
@@ -220,7 +220,5 @@ float provizio_nanoseconds_to_seconds(int64_t duration_ns)
     const float milliseconds_in_second = 1000.0F;
 
     return (float)(duration_ns / nanoseconds_in_millisecond) / // NOLINT: Potential losing of precision is indeed
-                                                               // expected due to limited float
-           milliseconds_in_second;
-    // capacity
+           milliseconds_in_second;                             // expected due to limited float capacity
 }

--- a/test/c_99/src/test_core.c
+++ b/test/c_99/src/test_core.c
@@ -66,11 +66,17 @@ enum
 {
     test_message_length = 1024
 };
-static char provizio_test_error[test_message_length]; // NOLINT: non-const global by design
+static char provizio_test_error[test_message_length];   // NOLINT: non-const global by design
+static char provizio_test_warning[test_message_length]; // NOLINT: non-const global by design
 
 static void test_provizio_on_error(const char *error)
 {
     strncpy(provizio_test_error, error, test_message_length - 1);
+}
+
+static void test_provizio_on_warning(const char *warning)
+{
+    strncpy(provizio_test_warning, warning, test_message_length - 1);
 }
 
 #ifdef WIN32
@@ -351,7 +357,7 @@ static int32_t test_receive_packet_on_packet_sent(const provizio_radar_point_clo
 
 static void test_receives_single_radar_point_cloud_from_single_radar(void)
 {
-    const uint16_t port_number = 10001 + PROVIZIO__RADAR_API_DEFAULT_PORT;
+    const uint16_t port_number = 20000 + __LINE__ + PROVIZIO__RADAR_API_DEFAULT_PORT;
     const uint32_t frame_index = 17;
     const uint64_t timestamp = 0x0123456789abcdef;
     const uint16_t radar_position_id = provizio_radar_position_rear_left;
@@ -433,7 +439,7 @@ static void test_receives_single_radar_point_cloud_from_single_radar(void)
 
 static void test_receives_single_radar_point_cloud_from_2_radars(void)
 {
-    const uint16_t port_number = 10002 + PROVIZIO__RADAR_API_DEFAULT_PORT;
+    const uint16_t port_number = 20000 + __LINE__ + PROVIZIO__RADAR_API_DEFAULT_PORT;
     const uint32_t frame_index = 17;
     const uint64_t timestamp = 0x0123456789abcdef;
     const uint16_t radar_position_ids[2] = {provizio_radar_position_rear_left, provizio_radar_position_front_center};
@@ -527,7 +533,7 @@ static void test_receives_single_radar_point_cloud_from_2_radars(void)
 
 static void test_receive_radar_point_cloud_frame_indices_overflow(void)
 {
-    const uint16_t port_number = 10005 + PROVIZIO__RADAR_API_DEFAULT_PORT;
+    const uint16_t port_number = 20000 + __LINE__ + PROVIZIO__RADAR_API_DEFAULT_PORT;
     const uint32_t frame_indices[3] = {0xfffffffe, 0xffffffff, 0};
     const uint64_t timestamp = 0x0123456789abcdef;
     const uint16_t radar_position_id = provizio_radar_position_rear_left;
@@ -564,10 +570,16 @@ static void test_receive_radar_point_cloud_frame_indices_overflow(void)
     TEST_ASSERT_EQUAL_INT32(0, status);
 
     // Send a complete frame, and make sure it got received while the incomplete one got dropped
+    provizio_set_on_warning(&test_provizio_on_warning);
+    provizio_test_warning[0] = '\0';
     status =
         send_test_point_cloud(port_number, frame_indices[2], timestamp, x_offsets[2], &radar_position_id, NULL, 1,
                               num_points, num_points, &test_receive_packet_on_packet_sent, &send_test_callback_data);
     TEST_ASSERT_EQUAL_INT32(0, status);
+    TEST_ASSERT_EQUAL_STRING(
+        "provizio_get_point_cloud_being_received: frame indices overflow detected - resetting API state",
+        provizio_test_warning);
+    provizio_set_on_warning(NULL);
 
     status = provizio_close_radar_connection(&connection);
     TEST_ASSERT_EQUAL_INT32(0, status);
@@ -582,7 +594,7 @@ static void test_receive_radar_point_cloud_frame_indices_overflow(void)
 
 static void test_receive_radar_point_cloud_frame_position_ids_mismatch(void)
 {
-    const uint16_t port_number = 10006 + PROVIZIO__RADAR_API_DEFAULT_PORT;
+    const uint16_t port_number = 20000 + __LINE__ + PROVIZIO__RADAR_API_DEFAULT_PORT;
     const uint32_t frame_index = 100;
     const uint64_t timestamp = 0x0123456789abcdef;
     const uint16_t radar_position_ids[2] = {provizio_radar_position_rear_left, provizio_radar_position_rear_right};
@@ -633,7 +645,7 @@ static void test_receive_radar_point_cloud_frame_position_ids_mismatch(void)
 
 static void test_receive_radar_point_cloud_drop_obsolete_incomplete_frame(void)
 {
-    const uint16_t port_number = 10007 + PROVIZIO__RADAR_API_DEFAULT_PORT;
+    const uint16_t port_number = 20000 + __LINE__ + PROVIZIO__RADAR_API_DEFAULT_PORT;
     const uint32_t frame_indices[3] = {17, 18, 19};
     const uint64_t timestamp = 0x0123456789abcdef;
     const uint16_t radar_position_id = provizio_radar_position_rear_left;
@@ -680,7 +692,7 @@ static void test_receive_radar_point_cloud_drop_obsolete_incomplete_frame(void)
 
 static void test_receive_radar_point_cloud_too_many_points(void)
 {
-    const uint16_t port_number = 10008 + PROVIZIO__RADAR_API_DEFAULT_PORT;
+    const uint16_t port_number = 20000 + __LINE__ + PROVIZIO__RADAR_API_DEFAULT_PORT;
     const uint32_t frame_index = 120;
     const uint64_t timestamp = 0x0123456789abcdef;
     const uint16_t radar_position_id = provizio_radar_position_rear_left;
@@ -707,6 +719,7 @@ static void test_receive_radar_point_cloud_too_many_points(void)
 
     // Send 2 more points, i.e. 1 too many
     provizio_set_on_error(&test_provizio_on_error);
+    provizio_test_error[0] = '\0';
     status = send_test_point_cloud(port_number, frame_index, timestamp, 1.0F, &radar_position_id, NULL, 1, num_points,
                                    num_extra_points, &test_receive_packet_on_packet_sent, &send_test_callback_data);
     TEST_ASSERT_EQUAL_INT32(PROVIZIO_E_PROTOCOL, status);
@@ -724,7 +737,7 @@ static void test_receive_radar_point_cloud_too_many_points(void)
 
 static void test_receive_radar_point_cloud_not_enough_contexts(void)
 {
-    const uint16_t port_number = 10009 + PROVIZIO__RADAR_API_DEFAULT_PORT;
+    const uint16_t port_number = 20000 + __LINE__ + PROVIZIO__RADAR_API_DEFAULT_PORT;
     const uint32_t frame_index = 17;
     const uint64_t timestamp = 0x0123456789abcdef;
     const uint16_t radar_position_ids[3] = {provizio_radar_position_rear_left, provizio_radar_position_front_center,
@@ -753,6 +766,7 @@ static void test_receive_radar_point_cloud_not_enough_contexts(void)
     send_test_callback_data.connection = &connection;
 
     provizio_set_on_error(&test_provizio_on_error);
+    provizio_test_error[0] = '\0';
     status =
         send_test_point_cloud(port_number, frame_index, timestamp, 0, radar_position_ids, NULL, num_radars, num_points,
                               num_points, &test_receive_packet_on_packet_sent, &send_test_callback_data);
@@ -770,7 +784,7 @@ static void test_receive_radar_point_cloud_not_enough_contexts(void)
 
 static void test_receive_radar_point_cloud_timeout_ok(void)
 {
-    const uint16_t port_number = 10003 + PROVIZIO__RADAR_API_DEFAULT_PORT;
+    const uint16_t port_number = 20000 + __LINE__ + PROVIZIO__RADAR_API_DEFAULT_PORT;
     const uint16_t first_frame_index = 500;
     const uint64_t initial_timestamp = 0x0123456789abcdef;
     uint16_t radar_position_id = provizio_radar_position_rear_left;
@@ -831,7 +845,7 @@ static void test_receive_radar_point_cloud_timeout_ok(void)
 
 static void test_receive_radar_point_cloud_timeout_fails(void)
 {
-    const uint16_t port_number = 10004 + PROVIZIO__RADAR_API_DEFAULT_PORT;
+    const uint16_t port_number = 20000 + __LINE__ + PROVIZIO__RADAR_API_DEFAULT_PORT;
     const uint64_t receive_timeout_ns = 100000000ULL; // 0.1s
     const int32_t thousand = 1000;
 
@@ -847,8 +861,8 @@ static void test_receive_radar_point_cloud_timeout_fails(void)
     TEST_ASSERT_EQUAL_INT32(PROVIZIO_E_TIMEOUT, provizio_open_radar_connection(port_number, receive_timeout_ns, 1,
                                                                                &api_context, &connection));
     TEST_ASSERT_EQUAL_INT32(0, provizio_gettimeofday(&time_now));
-    int32_t took_time_ms =
-        (int32_t)((time_now.tv_sec - time_was.tv_sec) * thousand + (time_now.tv_usec - time_was.tv_usec) / thousand);
+    int32_t took_time_ms = (int32_t)(((time_now.tv_sec - time_was.tv_sec) * thousand) +
+                                     ((time_now.tv_usec - time_was.tv_usec) / thousand));
     TEST_ASSERT_GREATER_OR_EQUAL_INT32(90, took_time_ms); // Allow missing 10ms due to system timer's inaccuracy
     TEST_ASSERT_LESS_THAN_INT32(200, took_time_ms);
 
@@ -860,8 +874,8 @@ static void test_receive_radar_point_cloud_timeout_fails(void)
     TEST_ASSERT_EQUAL_INT32(0, provizio_gettimeofday(&time_was));
     TEST_ASSERT_EQUAL_INT32(PROVIZIO_E_TIMEOUT, provizio_radar_api_receive_packet(&connection));
     TEST_ASSERT_EQUAL_INT32(0, provizio_gettimeofday(&time_now));
-    took_time_ms =
-        (int32_t)((time_now.tv_sec - time_was.tv_sec) * thousand + (time_now.tv_usec - time_was.tv_usec) / thousand);
+    took_time_ms = (int32_t)(((time_now.tv_sec - time_was.tv_sec) * thousand) +
+                             ((time_now.tv_usec - time_was.tv_usec) / thousand));
     TEST_ASSERT_GREATER_OR_EQUAL_INT32(100, took_time_ms); // Allow missing 10ms due to system timer's inaccuracy
     TEST_ASSERT_LESS_THAN_INT32(200, took_time_ms);
 
@@ -870,24 +884,26 @@ static void test_receive_radar_point_cloud_timeout_fails(void)
 
 static void test_provizio_radar_point_cloud_api_contexts_receive_packet_fails_as_not_connected(void)
 {
-    provizio_radar_api_connection api_connetion;
-    memset(&api_connetion, 0, sizeof(api_connetion));
-    api_connetion.sock = PROVIZIO__INVALID_SOCKET;
+    provizio_radar_api_connection api_connection;
+    memset(&api_connection, 0, sizeof(api_connection));
+    api_connection.sock = PROVIZIO__INVALID_SOCKET;
 
     provizio_set_on_error(&test_provizio_on_error);
-    TEST_ASSERT_EQUAL_INT32(PROVIZIO_E_ARGUMENT, provizio_radar_api_receive_packet(&api_connetion));
+    provizio_test_error[0] = '\0';
+    TEST_ASSERT_EQUAL_INT32(PROVIZIO_E_ARGUMENT, provizio_radar_api_receive_packet(&api_connection));
     TEST_ASSERT_EQUAL_STRING("provizio_radar_api_receive_packet: Not connected", provizio_test_error);
     provizio_set_on_error(NULL);
 }
 
 static void test_provizio_radar_point_cloud_api_close_fails_as_not_connected(void)
 {
-    provizio_radar_api_connection api_connetion;
-    memset(&api_connetion, 0, sizeof(api_connetion));
-    api_connetion.sock = PROVIZIO__INVALID_SOCKET;
+    provizio_radar_api_connection api_connection;
+    memset(&api_connection, 0, sizeof(api_connection));
+    api_connection.sock = PROVIZIO__INVALID_SOCKET;
 
     provizio_set_on_error(&test_provizio_on_error);
-    TEST_ASSERT_EQUAL_INT32(PROVIZIO_E_ARGUMENT, provizio_close_radar_connection(&api_connetion));
+    provizio_test_error[0] = '\0';
+    TEST_ASSERT_EQUAL_INT32(PROVIZIO_E_ARGUMENT, provizio_close_radar_connection(&api_connection));
     TEST_ASSERT_EQUAL_STRING("provizio_close_radars_connection: Not connected", provizio_test_error);
     provizio_set_on_error(NULL);
 }
@@ -898,11 +914,16 @@ typedef struct test_provizio_set_radar_range_radar_thread_data
     int32_t ready_flag;
 
     uint16_t port_number;
-    uint16_t packet_type;
-    uint16_t protocol_version;
+    uint16_t packet_type_ack;
+    uint16_t packet_type_response;
+    int32_t time_before_response_sec;
+    uint16_t protocol_version_ack;
+    uint16_t protocol_version_response;
     uint16_t radar_position_id;
     uint16_t requested_radar_range;
-    int32_t error_code;
+    uint16_t current_range_was;
+    int32_t error_code_ack;
+    int32_t error_code_response;
 
     provizio_set_radar_range_packet requested_packet;
 } test_provizio_set_radar_range_radar_thread_data;
@@ -913,6 +934,7 @@ static void *test_provizio_set_radar_range_radar_thread(void *thread_data_void)
         (test_provizio_set_radar_range_radar_thread_data *)thread_data_void;
 
     PROVIZIO__SOCKET sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    TEST_ASSERT_TRUE(provizio_socket_valid(sock));
 
     struct sockaddr_in my_address;
     memset(&my_address, 0, sizeof(my_address));
@@ -931,23 +953,57 @@ static void *test_provizio_set_radar_range_radar_thread(void *thread_data_void)
         if ((size_t)recvfrom(sock, (char *)&thread_data->requested_packet, sizeof(provizio_set_radar_range_packet), 0,
                              &from, &from_len) == sizeof(provizio_set_radar_range_packet))
         {
-            provizio_set_radar_range_acknowledgement_packet acknowledgement_packet;
-            memset(&acknowledgement_packet, 0, sizeof(acknowledgement_packet));
-            provizio_set_protocol_field_uint16_t(&acknowledgement_packet.protocol_header.packet_type,
-                                                 thread_data->packet_type);
-            provizio_set_protocol_field_uint16_t(&acknowledgement_packet.protocol_header.protocol_version,
-                                                 thread_data->protocol_version);
-            provizio_set_protocol_field_uint16_t(&acknowledgement_packet.radar_position_id,
-                                                 thread_data->radar_position_id);
-            provizio_set_protocol_field_uint16_t(&acknowledgement_packet.requested_radar_range,
+            provizio_set_radar_range_response_packet response_packet;
+            memset(&response_packet, 0, sizeof(response_packet));
+            provizio_set_protocol_field_uint16_t(&response_packet.protocol_header.packet_type,
+                                                 thread_data->packet_type_ack);
+            provizio_set_protocol_field_uint16_t(&response_packet.protocol_header.protocol_version,
+                                                 thread_data->protocol_version_ack);
+            provizio_set_protocol_field_uint16_t(&response_packet.radar_position_id, thread_data->radar_position_id);
+            provizio_set_protocol_field_uint16_t(&response_packet.requested_radar_range,
                                                  thread_data->requested_radar_range);
-            provizio_set_protocol_field_uint32_t((uint32_t *)&acknowledgement_packet.error_code,
-                                                 (uint32_t)thread_data->error_code);
+            provizio_set_protocol_field_uint16_t(&response_packet.current_radar_range, thread_data->current_range_was);
+            provizio_set_protocol_field_uint32_t((uint32_t *)&response_packet.error_code,
+                                                 (uint32_t)thread_data->error_code_ack);
 
-            (void)sendto(sock, (const char *)&acknowledgement_packet, sizeof(acknowledgement_packet), 0, &from,
-                         from_len);
+            (void)sendto(sock, (const char *)&response_packet, sizeof(response_packet), 0, &from, from_len);
+
+            // Send the response if required
+            if (thread_data->current_range_was != thread_data->requested_radar_range &&
+                thread_data->requested_radar_range != provizio_radar_range_unknown &&
+                thread_data->packet_type_response != 0)
+            {
+                if (thread_data->time_before_response_sec > 0)
+                {
+                    // Sleep to simulate time taken to switch the range
+                    struct timespec sleep_timespec;
+                    sleep_timespec.tv_sec = thread_data->time_before_response_sec;
+                    sleep_timespec.tv_nsec = 0;
+                    nanosleep(&sleep_timespec, NULL);
+                }
+
+                provizio_set_protocol_field_uint16_t(&response_packet.protocol_header.packet_type,
+                                                     thread_data->packet_type_response);
+                provizio_set_protocol_field_uint16_t(&response_packet.protocol_header.protocol_version,
+                                                     thread_data->protocol_version_response);
+                provizio_set_protocol_field_uint32_t((uint32_t *)&response_packet.error_code,
+                                                     (uint32_t)thread_data->error_code_response);
+                if (thread_data->error_code_response == 0)
+                {
+                    provizio_set_protocol_field_uint16_t(&response_packet.current_radar_range,
+                                                         thread_data->requested_radar_range);
+                }
+
+                (void)sendto(sock, (const char *)&response_packet, sizeof(response_packet), 0, &from, from_len);
+            }
         }
     }
+    // LCOV_EXCL_START: Shouldn't happen, failing to bind the test server socket would fail the tests
+    else
+    {
+        provizio_error("test_provizio_set_radar_range_radar_thread: Failed to bind the test server socket!");
+    }
+    // LCOV_EXCL_STOP
 
     provizio_socket_close(sock);
 
@@ -978,9 +1034,9 @@ static void wait_till_test_provizio_set_radar_range_radar_thread_ready(
     }
 }
 
-static void test_provizio_set_radar_range_ok(void)
+static void test_provizio_set_radar_range_ok_already_set(void)
 {
-    const uint16_t port_number = 10011 + PROVIZIO__RADAR_API_SET_RANGE_DEFAULT_PORT;
+    const uint16_t port_number = 20000 + __LINE__ + PROVIZIO__RADAR_API_DEFAULT_PORT;
     const provizio_radar_position radar_position_id = provizio_radar_position_rear_right;
     const provizio_radar_range range = provizio_radar_range_long;
 
@@ -988,20 +1044,27 @@ static void test_provizio_set_radar_range_ok(void)
     pthread_mutex_t mutex;
     TEST_ASSERT_EQUAL(0, pthread_mutex_init(&mutex, NULL));
     test_provizio_set_radar_range_radar_thread_data thread_data;
+    memset(&thread_data, 0, sizeof(thread_data));
     thread_data.mutex = &mutex;
     thread_data.ready_flag = 0;
     thread_data.port_number = port_number;
-    thread_data.packet_type = PROVIZIO__RADAR_API_SET_RANGE_ACKNOWLEDGEMENT_PACKET_TYPE;
-    thread_data.protocol_version = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
+    thread_data.packet_type_ack = PROVIZIO__RADAR_API_SET_RANGE_ACKNOWLEDGEMENT_PACKET_TYPE;
+    thread_data.packet_type_response = PROVIZIO__RADAR_API_SET_RANGE_RESPONSE_PACKET_TYPE;
+    thread_data.protocol_version_ack = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
+    thread_data.protocol_version_response = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
     thread_data.radar_position_id = radar_position_id;
     thread_data.requested_radar_range = range;
-    thread_data.error_code = 0;
+    thread_data.current_range_was = range;
+    thread_data.error_code_ack = 0;
+    thread_data.error_code_response = 0;
     pthread_t radar_thread; // NOLINT: Initialized in the next line
     TEST_ASSERT_EQUAL_INT32(
         0, pthread_create(&radar_thread, NULL, &test_provizio_set_radar_range_radar_thread, &thread_data));
     wait_till_test_provizio_set_radar_range_radar_thread_ready(&thread_data);
 
-    TEST_ASSERT_EQUAL(0, provizio_set_radar_range(radar_position_id, range, port_number, "127.0.0.1"));
+    provizio_radar_range actual_radar_range = provizio_radar_range_hyper_long;
+    TEST_ASSERT_EQUAL(
+        0, provizio_set_radar_range(radar_position_id, range, port_number, "127.0.0.1", &actual_radar_range));
 
     TEST_ASSERT_EQUAL(0, pthread_join(radar_thread, NULL));
     TEST_ASSERT_EQUAL(0, pthread_mutex_destroy(&mutex));
@@ -1014,32 +1077,90 @@ static void test_provizio_set_radar_range_ok(void)
     TEST_ASSERT_EQUAL((uint16_t)radar_position_id,
                       provizio_get_protocol_field_uint16_t(&thread_data.requested_packet.radar_position_id));
     TEST_ASSERT_EQUAL((uint16_t)range, provizio_get_protocol_field_uint16_t(&thread_data.requested_packet.radar_range));
+    TEST_ASSERT_EQUAL((uint16_t)range, actual_radar_range);
+}
+
+static void test_provizio_set_radar_range_ok(void)
+{
+    const uint16_t port_number = 20000 + __LINE__ + PROVIZIO__RADAR_API_DEFAULT_PORT;
+    const provizio_radar_position radar_position_id = provizio_radar_position_rear_right;
+    const provizio_radar_range range = provizio_radar_range_long;
+    const provizio_radar_range range_was = provizio_radar_range_short;
+    const int32_t time_before_response_sec = 10;
+
+    // Start the test radar thread
+    pthread_mutex_t mutex;
+    TEST_ASSERT_EQUAL(0, pthread_mutex_init(&mutex, NULL));
+    test_provizio_set_radar_range_radar_thread_data thread_data;
+    memset(&thread_data, 0, sizeof(thread_data));
+    thread_data.mutex = &mutex;
+    thread_data.ready_flag = 0;
+    thread_data.port_number = port_number;
+    thread_data.packet_type_ack = PROVIZIO__RADAR_API_SET_RANGE_ACKNOWLEDGEMENT_PACKET_TYPE;
+    thread_data.packet_type_response = PROVIZIO__RADAR_API_SET_RANGE_RESPONSE_PACKET_TYPE;
+    thread_data.protocol_version_ack = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
+    thread_data.protocol_version_response = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
+    thread_data.radar_position_id = radar_position_id;
+    thread_data.requested_radar_range = range;
+    thread_data.current_range_was = range_was;
+    thread_data.time_before_response_sec = time_before_response_sec;
+    thread_data.error_code_ack = 0;
+    thread_data.error_code_response = 0;
+    pthread_t radar_thread; // NOLINT: Initialized in the next line
+    TEST_ASSERT_EQUAL_INT32(
+        0, pthread_create(&radar_thread, NULL, &test_provizio_set_radar_range_radar_thread, &thread_data));
+    wait_till_test_provizio_set_radar_range_radar_thread_ready(&thread_data);
+
+    provizio_radar_range actual_radar_range = provizio_radar_range_hyper_long;
+    TEST_ASSERT_EQUAL(
+        0, provizio_set_radar_range(radar_position_id, range, port_number, "127.0.0.1", &actual_radar_range));
+
+    TEST_ASSERT_EQUAL(0, pthread_join(radar_thread, NULL));
+    TEST_ASSERT_EQUAL(0, pthread_mutex_destroy(&mutex));
+
+    TEST_ASSERT_EQUAL(PROVIZIO__RADAR_API_SET_RANGE_PACKET_TYPE,
+                      provizio_get_protocol_field_uint16_t(&thread_data.requested_packet.protocol_header.packet_type));
+    TEST_ASSERT_EQUAL(
+        PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION,
+        provizio_get_protocol_field_uint16_t(&thread_data.requested_packet.protocol_header.protocol_version));
+    TEST_ASSERT_EQUAL((uint16_t)radar_position_id,
+                      provizio_get_protocol_field_uint16_t(&thread_data.requested_packet.radar_position_id));
+    TEST_ASSERT_EQUAL((uint16_t)range, provizio_get_protocol_field_uint16_t(&thread_data.requested_packet.radar_range));
+    TEST_ASSERT_EQUAL((uint16_t)range, actual_radar_range);
 }
 
 static void test_provizio_set_radar_range_broadcasting_ok(void)
 {
-    const uint16_t port_number = 10012 + PROVIZIO__RADAR_API_SET_RANGE_DEFAULT_PORT;
+    const uint16_t port_number = 20000 + __LINE__ + PROVIZIO__RADAR_API_DEFAULT_PORT;
     const provizio_radar_position radar_position_id = provizio_radar_position_rear_right;
     const provizio_radar_range range = provizio_radar_range_long;
+    const provizio_radar_range range_was = provizio_radar_range_hyper_long;
 
     // Start the test radar thread
     pthread_mutex_t mutex;
     TEST_ASSERT_EQUAL(0, pthread_mutex_init(&mutex, NULL));
     test_provizio_set_radar_range_radar_thread_data thread_data;
+    memset(&thread_data, 0, sizeof(thread_data));
     thread_data.mutex = &mutex;
     thread_data.ready_flag = 0;
     thread_data.port_number = port_number;
-    thread_data.packet_type = PROVIZIO__RADAR_API_SET_RANGE_ACKNOWLEDGEMENT_PACKET_TYPE;
-    thread_data.protocol_version = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
+    thread_data.packet_type_ack = PROVIZIO__RADAR_API_SET_RANGE_ACKNOWLEDGEMENT_PACKET_TYPE;
+    thread_data.packet_type_response = PROVIZIO__RADAR_API_SET_RANGE_RESPONSE_PACKET_TYPE;
+    thread_data.protocol_version_ack = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
+    thread_data.protocol_version_response = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
     thread_data.radar_position_id = radar_position_id;
     thread_data.requested_radar_range = range;
-    thread_data.error_code = 0;
+    thread_data.current_range_was = range_was;
+    thread_data.error_code_ack = 0;
+    thread_data.error_code_response = 0;
     pthread_t radar_thread; // NOLINT: Initialized in the next line
     TEST_ASSERT_EQUAL_INT32(
         0, pthread_create(&radar_thread, NULL, &test_provizio_set_radar_range_radar_thread, &thread_data));
     wait_till_test_provizio_set_radar_range_radar_thread_ready(&thread_data);
 
-    TEST_ASSERT_EQUAL(0, provizio_set_radar_range(radar_position_id, range, port_number, "255.255.255.255"));
+    provizio_radar_range actual_radar_range = provizio_radar_range_hyper_long;
+    TEST_ASSERT_EQUAL(
+        0, provizio_set_radar_range(radar_position_id, range, port_number, "255.255.255.255", &actual_radar_range));
 
     TEST_ASSERT_EQUAL(0, pthread_join(radar_thread, NULL));
     TEST_ASSERT_EQUAL(0, pthread_mutex_destroy(&mutex));
@@ -1052,63 +1173,264 @@ static void test_provizio_set_radar_range_broadcasting_ok(void)
     TEST_ASSERT_EQUAL((uint16_t)radar_position_id,
                       provizio_get_protocol_field_uint16_t(&thread_data.requested_packet.radar_position_id));
     TEST_ASSERT_EQUAL((uint16_t)range, provizio_get_protocol_field_uint16_t(&thread_data.requested_packet.radar_range));
+    TEST_ASSERT_EQUAL((uint16_t)range, actual_radar_range);
 }
 
-static void test_provizio_set_radar_range_invalid_range(void)
+static void test_provizio_set_radar_range_unknown_range(void)
 {
-    const uint16_t port_number = 10013 + PROVIZIO__RADAR_API_SET_RANGE_DEFAULT_PORT;
+    const uint16_t port_number = 20000 + __LINE__ + PROVIZIO__RADAR_API_DEFAULT_PORT;
     // radar_position_id, range
     const provizio_radar_position radar_position_id = provizio_radar_position_rear_right;
     const provizio_radar_range range = provizio_radar_range_unknown;
-
-    provizio_set_on_error(&test_provizio_on_error);
-    TEST_ASSERT_EQUAL(PROVIZIO_E_ARGUMENT,
-                      provizio_set_radar_range(radar_position_id, range, port_number, "127.0.0.1"));
-    TEST_ASSERT_EQUAL_STRING("provizio_set_radar_range: provizio_radar_range_unknown is not a valid range option!",
-                             provizio_test_error);
-    provizio_set_on_error(NULL);
-}
-
-static void test_provizio_set_radar_range_timeout(void)
-{
-    const uint16_t port_number = 10014 + PROVIZIO__RADAR_API_SET_RANGE_DEFAULT_PORT;
-    const provizio_radar_position radar_position_id = provizio_radar_position_rear_right;
-    const provizio_radar_range range = provizio_radar_range_long;
-
-    provizio_set_on_error(&test_provizio_on_error);
-    TEST_ASSERT_EQUAL(PROVIZIO_E_TIMEOUT, provizio_set_radar_range(radar_position_id, range, port_number, "127.0.0.1"));
-    TEST_ASSERT_EQUAL_STRING("provizio_set_radar_range: No acknowledgement received, likely due to a connection issue",
-                             provizio_test_error);
-    provizio_set_on_error(NULL);
-}
-
-static void test_provizio_set_radar_range_invalid_ack_packet_type(void)
-{
-    const uint16_t port_number = 10015 + PROVIZIO__RADAR_API_SET_RANGE_DEFAULT_PORT;
-    const provizio_radar_position radar_position_id = provizio_radar_position_rear_right;
-    const provizio_radar_range range = provizio_radar_range_long;
+    const provizio_radar_range range_was = provizio_radar_range_medium;
 
     // Start the test radar thread
     pthread_mutex_t mutex;
     TEST_ASSERT_EQUAL(0, pthread_mutex_init(&mutex, NULL));
     test_provizio_set_radar_range_radar_thread_data thread_data;
+    memset(&thread_data, 0, sizeof(thread_data));
     thread_data.mutex = &mutex;
     thread_data.ready_flag = 0;
     thread_data.port_number = port_number;
-    thread_data.packet_type = PROVIZIO__RADAR_API_SET_RANGE_ACKNOWLEDGEMENT_PACKET_TYPE + 1;
-    thread_data.protocol_version = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
+    thread_data.packet_type_ack = PROVIZIO__RADAR_API_SET_RANGE_ACKNOWLEDGEMENT_PACKET_TYPE;
+    thread_data.packet_type_response = PROVIZIO__RADAR_API_SET_RANGE_RESPONSE_PACKET_TYPE;
+    thread_data.protocol_version_ack = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
+    thread_data.protocol_version_response = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
     thread_data.radar_position_id = radar_position_id;
     thread_data.requested_radar_range = range;
-    thread_data.error_code = 0;
+    thread_data.current_range_was = range_was;
+    thread_data.error_code_ack = PROVIZIO_E_SKIPPED;
+    thread_data.error_code_response = 0;
     pthread_t radar_thread; // NOLINT: Initialized in the next line
     TEST_ASSERT_EQUAL_INT32(
         0, pthread_create(&radar_thread, NULL, &test_provizio_set_radar_range_radar_thread, &thread_data));
     wait_till_test_provizio_set_radar_range_radar_thread_ready(&thread_data);
 
     provizio_set_on_error(&test_provizio_on_error);
-    TEST_ASSERT_EQUAL(PROVIZIO_E_PROTOCOL,
-                      provizio_set_radar_range(radar_position_id, range, port_number, "127.0.0.1"));
-    TEST_ASSERT_EQUAL_STRING("provizio_set_radar_range: Invalid acknowledgement packet type received",
+    provizio_test_error[0] = '\0';
+    provizio_radar_range actual_radar_range = provizio_radar_range_hyper_long;
+    TEST_ASSERT_EQUAL(PROVIZIO_E_SKIPPED, provizio_set_radar_range(radar_position_id, range, port_number, "127.0.0.1",
+                                                                   &actual_radar_range));
+
+    TEST_ASSERT_EQUAL(0, pthread_join(radar_thread, NULL));
+    TEST_ASSERT_EQUAL(0, pthread_mutex_destroy(&mutex));
+
+    TEST_ASSERT_EQUAL(range_was, actual_radar_range);
+    // Setting an unknown range is not really an error and is used to request the current range
+    TEST_ASSERT_EQUAL_STRING("", provizio_test_error);
+    provizio_set_on_error(NULL);
+}
+
+static void test_provizio_set_radar_range_huge_timeout(void)
+{
+    const uint16_t port_number = 20000 + __LINE__ + PROVIZIO__RADAR_API_DEFAULT_PORT;
+    // radar_position_id, range
+    const provizio_radar_position radar_position_id = provizio_radar_position_rear_right;
+    const provizio_radar_range range = provizio_radar_range_medium;
+    const uint64_t huge_timeout = (uint64_t)INT32_MAX * 250000000ULL;
+
+    provizio_set_on_error(&test_provizio_on_error);
+    provizio_test_error[0] = '\0';
+    provizio_radar_range actual_radar_range = provizio_radar_range_hyper_long;
+    TEST_ASSERT_EQUAL(PROVIZIO_E_ARGUMENT,
+                      provizio_set_radar_range_with_timeout(radar_position_id, range, port_number, "127.0.0.1",
+                                                            &actual_radar_range, huge_timeout));
+
+    TEST_ASSERT_EQUAL(provizio_radar_range_unknown, actual_radar_range);
+    TEST_ASSERT_EQUAL_STRING("provizio_set_radar_range_with_timeout: timeout_ns is too large", provizio_test_error);
+    provizio_set_on_error(NULL);
+}
+
+static void test_provizio_set_radar_range_ack_timeout(void)
+{
+    const uint16_t port_number = 20000 + __LINE__ + PROVIZIO__RADAR_API_DEFAULT_PORT;
+    const provizio_radar_position radar_position_id = provizio_radar_position_rear_right;
+    const provizio_radar_range range = provizio_radar_range_long;
+
+    provizio_set_on_error(&test_provizio_on_error);
+    provizio_test_error[0] = '\0';
+    TEST_ASSERT_EQUAL(PROVIZIO_E_TIMEOUT,
+                      provizio_set_radar_range(radar_position_id, range, port_number, "127.0.0.1", NULL));
+    TEST_ASSERT_EQUAL_STRING(
+        "provizio_set_radar_range_with_timeout: No acknowledgement received, likely due to a connection issue",
+        provizio_test_error);
+    provizio_set_on_error(NULL);
+}
+
+static void test_provizio_set_radar_range_response_timeout(void)
+{
+    const uint16_t port_number = 20000 + __LINE__ + PROVIZIO__RADAR_API_DEFAULT_PORT;
+    const provizio_radar_position radar_position_id = provizio_radar_position_rear_right;
+    const provizio_radar_range range = provizio_radar_range_long;
+    const provizio_radar_range range_was = provizio_radar_range_short;
+    const int32_t time_before_response_sec = 4;
+    const uint64_t set_range_timeout_ns = 2000000000ULL; // 2 seconds
+
+    // Start the test radar thread
+    pthread_mutex_t mutex;
+    TEST_ASSERT_EQUAL(0, pthread_mutex_init(&mutex, NULL));
+    test_provizio_set_radar_range_radar_thread_data thread_data;
+    memset(&thread_data, 0, sizeof(thread_data));
+    thread_data.mutex = &mutex;
+    thread_data.ready_flag = 0;
+    thread_data.port_number = port_number;
+    thread_data.packet_type_ack = PROVIZIO__RADAR_API_SET_RANGE_ACKNOWLEDGEMENT_PACKET_TYPE;
+    thread_data.packet_type_response = PROVIZIO__RADAR_API_SET_RANGE_RESPONSE_PACKET_TYPE;
+    thread_data.protocol_version_ack = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
+    thread_data.protocol_version_response = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
+    thread_data.radar_position_id = radar_position_id;
+    thread_data.requested_radar_range = range;
+    thread_data.current_range_was = range_was;
+    thread_data.time_before_response_sec = time_before_response_sec;
+    thread_data.error_code_ack = 0;
+    thread_data.error_code_response = 0;
+    pthread_t radar_thread; // NOLINT: Initialized in the next line
+    TEST_ASSERT_EQUAL_INT32(
+        0, pthread_create(&radar_thread, NULL, &test_provizio_set_radar_range_radar_thread, &thread_data));
+    wait_till_test_provizio_set_radar_range_radar_thread_ready(&thread_data);
+
+    provizio_set_on_error(&test_provizio_on_error);
+    provizio_test_error[0] = '\0';
+    provizio_radar_range actual_radar_range = provizio_radar_range_hyper_long;
+    TEST_ASSERT_EQUAL(PROVIZIO_E_TIMEOUT,
+                      provizio_set_radar_range_with_timeout(radar_position_id, range, port_number, "127.0.0.1",
+                                                            &actual_radar_range, set_range_timeout_ns));
+    TEST_ASSERT_EQUAL(range_was, actual_radar_range);
+    TEST_ASSERT_EQUAL_STRING("provizio_set_radar_range_with_timeout: Received the acknowledgement but not the response",
+                             provizio_test_error);
+    provizio_set_on_error(NULL);
+
+    TEST_ASSERT_EQUAL(0, pthread_join(radar_thread, NULL));
+    TEST_ASSERT_EQUAL(0, pthread_mutex_destroy(&mutex));
+}
+
+static void test_provizio_set_radar_range_invalid_ack_packet_type(void)
+{
+    const uint16_t port_number = 20000 + __LINE__ + PROVIZIO__RADAR_API_DEFAULT_PORT;
+    const provizio_radar_position radar_position_id = provizio_radar_position_rear_right;
+    const provizio_radar_range range = provizio_radar_range_long;
+    const provizio_radar_range range_was = provizio_radar_range_medium;
+    const uint16_t packet_type_offset = 10;
+
+    // Start the test radar thread
+    pthread_mutex_t mutex;
+    TEST_ASSERT_EQUAL(0, pthread_mutex_init(&mutex, NULL));
+    test_provizio_set_radar_range_radar_thread_data thread_data;
+    memset(&thread_data, 0, sizeof(thread_data));
+    thread_data.mutex = &mutex;
+    thread_data.ready_flag = 0;
+    thread_data.port_number = port_number;
+    thread_data.packet_type_ack = PROVIZIO__RADAR_API_SET_RANGE_ACKNOWLEDGEMENT_PACKET_TYPE + packet_type_offset;
+    thread_data.packet_type_response = PROVIZIO__RADAR_API_SET_RANGE_RESPONSE_PACKET_TYPE;
+    thread_data.protocol_version_ack = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
+    thread_data.protocol_version_response = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
+    thread_data.radar_position_id = radar_position_id;
+    thread_data.requested_radar_range = range;
+    thread_data.current_range_was = range_was;
+    thread_data.error_code_ack = 0;
+    thread_data.error_code_response = 0;
+    pthread_t radar_thread; // NOLINT: Initialized in the next line
+    TEST_ASSERT_EQUAL_INT32(
+        0, pthread_create(&radar_thread, NULL, &test_provizio_set_radar_range_radar_thread, &thread_data));
+    wait_till_test_provizio_set_radar_range_radar_thread_ready(&thread_data);
+
+    provizio_set_on_error(&test_provizio_on_error);
+    provizio_test_error[0] = '\0';
+    provizio_radar_range actual_radar_range = provizio_radar_range_hyper_long;
+    TEST_ASSERT_EQUAL(PROVIZIO_E_PROTOCOL, provizio_set_radar_range(radar_position_id, range, port_number, "127.0.0.1",
+                                                                    &actual_radar_range));
+    TEST_ASSERT_EQUAL(provizio_radar_range_unknown, actual_radar_range);
+    TEST_ASSERT_EQUAL_STRING("provizio_set_radar_range_with_timeout: Invalid acknowledgement packet type received",
+                             provizio_test_error);
+    provizio_set_on_error(NULL);
+
+    TEST_ASSERT_EQUAL(0, pthread_join(radar_thread, NULL));
+    TEST_ASSERT_EQUAL(0, pthread_mutex_destroy(&mutex));
+}
+
+static void test_provizio_set_radar_range_invalid_response_packet_type(void)
+{
+    const uint16_t port_number = 20000 + __LINE__ + PROVIZIO__RADAR_API_DEFAULT_PORT;
+    const provizio_radar_position radar_position_id = provizio_radar_position_rear_right;
+    const provizio_radar_range range = provizio_radar_range_long;
+    const provizio_radar_range range_was = provizio_radar_range_medium;
+    const uint16_t packet_type_offset = 10;
+
+    // Start the test radar thread
+    pthread_mutex_t mutex;
+    TEST_ASSERT_EQUAL(0, pthread_mutex_init(&mutex, NULL));
+    test_provizio_set_radar_range_radar_thread_data thread_data;
+    memset(&thread_data, 0, sizeof(thread_data));
+    thread_data.mutex = &mutex;
+    thread_data.ready_flag = 0;
+    thread_data.port_number = port_number;
+    thread_data.packet_type_ack = PROVIZIO__RADAR_API_SET_RANGE_ACKNOWLEDGEMENT_PACKET_TYPE;
+    thread_data.packet_type_response = PROVIZIO__RADAR_API_SET_RANGE_RESPONSE_PACKET_TYPE + packet_type_offset;
+    thread_data.protocol_version_ack = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
+    thread_data.protocol_version_response = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
+    thread_data.radar_position_id = radar_position_id;
+    thread_data.requested_radar_range = range;
+    thread_data.current_range_was = range_was;
+    thread_data.error_code_ack = 0;
+    thread_data.error_code_response = 0;
+    pthread_t radar_thread; // NOLINT: Initialized in the next line
+    TEST_ASSERT_EQUAL_INT32(
+        0, pthread_create(&radar_thread, NULL, &test_provizio_set_radar_range_radar_thread, &thread_data));
+    wait_till_test_provizio_set_radar_range_radar_thread_ready(&thread_data);
+
+    provizio_set_on_error(&test_provizio_on_error);
+    provizio_test_error[0] = '\0';
+    provizio_radar_range actual_radar_range = provizio_radar_range_hyper_long;
+    TEST_ASSERT_EQUAL(PROVIZIO_E_PROTOCOL, provizio_set_radar_range(radar_position_id, range, port_number, "127.0.0.1",
+                                                                    &actual_radar_range));
+    TEST_ASSERT_EQUAL(range_was, actual_radar_range);
+    TEST_ASSERT_EQUAL_STRING("provizio_set_radar_range_with_timeout: Invalid response packet type received",
+                             provizio_test_error);
+    provizio_set_on_error(NULL);
+
+    TEST_ASSERT_EQUAL(0, pthread_join(radar_thread, NULL));
+    TEST_ASSERT_EQUAL(0, pthread_mutex_destroy(&mutex));
+}
+
+static void test_provizio_set_radar_range_response_packet_type_from_previous_request(void)
+{
+    const uint16_t port_number = 20000 + __LINE__ + PROVIZIO__RADAR_API_DEFAULT_PORT;
+    const provizio_radar_position radar_position_id = provizio_radar_position_rear_right;
+    const provizio_radar_range range = provizio_radar_range_long;
+    const provizio_radar_range range_was = provizio_radar_range_medium;
+    const uint64_t set_range_timeout_ns = 1000000000ULL; // 1 second
+
+    // Start the test radar thread
+    pthread_mutex_t mutex;
+    TEST_ASSERT_EQUAL(0, pthread_mutex_init(&mutex, NULL));
+    test_provizio_set_radar_range_radar_thread_data thread_data;
+    memset(&thread_data, 0, sizeof(thread_data));
+    thread_data.mutex = &mutex;
+    thread_data.ready_flag = 0;
+    thread_data.port_number = port_number;
+    thread_data.packet_type_ack = PROVIZIO__RADAR_API_SET_RANGE_ACKNOWLEDGEMENT_PACKET_TYPE;
+    thread_data.packet_type_response =
+        PROVIZIO__RADAR_API_SET_RANGE_ACKNOWLEDGEMENT_PACKET_TYPE; // Acknowledgment to be received instead of response
+    thread_data.protocol_version_ack = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
+    thread_data.protocol_version_response = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
+    thread_data.radar_position_id = radar_position_id;
+    thread_data.requested_radar_range = range;
+    thread_data.current_range_was = range_was;
+    thread_data.error_code_ack = 0;
+    thread_data.error_code_response = 0;
+    pthread_t radar_thread; // NOLINT: Initialized in the next line
+    TEST_ASSERT_EQUAL_INT32(
+        0, pthread_create(&radar_thread, NULL, &test_provizio_set_radar_range_radar_thread, &thread_data));
+    wait_till_test_provizio_set_radar_range_radar_thread_ready(&thread_data);
+
+    provizio_set_on_error(&test_provizio_on_error);
+    provizio_test_error[0] = '\0';
+    provizio_radar_range actual_radar_range = provizio_radar_range_hyper_long;
+    TEST_ASSERT_EQUAL(PROVIZIO_E_TIMEOUT,
+                      provizio_set_radar_range_with_timeout(radar_position_id, range, port_number, "127.0.0.1",
+                                                            &actual_radar_range, set_range_timeout_ns));
+    TEST_ASSERT_EQUAL(range_was, actual_radar_range);
+    TEST_ASSERT_EQUAL_STRING("provizio_set_radar_range_with_timeout: Received the acknowledgement but not the response",
                              provizio_test_error);
     provizio_set_on_error(NULL);
 
@@ -1118,7 +1440,7 @@ static void test_provizio_set_radar_range_invalid_ack_packet_type(void)
 
 static void test_provizio_set_radar_range_invalid_ack_protocol_version(void)
 {
-    const uint16_t port_number = 10016 + PROVIZIO__RADAR_API_SET_RANGE_DEFAULT_PORT;
+    const uint16_t port_number = 20000 + __LINE__ + PROVIZIO__RADAR_API_DEFAULT_PORT;
     const provizio_radar_position radar_position_id = provizio_radar_position_rear_right;
     const provizio_radar_range range = provizio_radar_range_long;
 
@@ -1126,23 +1448,74 @@ static void test_provizio_set_radar_range_invalid_ack_protocol_version(void)
     pthread_mutex_t mutex;
     TEST_ASSERT_EQUAL(0, pthread_mutex_init(&mutex, NULL));
     test_provizio_set_radar_range_radar_thread_data thread_data;
+    memset(&thread_data, 0, sizeof(thread_data));
     thread_data.mutex = &mutex;
     thread_data.ready_flag = 0;
     thread_data.port_number = port_number;
-    thread_data.packet_type = PROVIZIO__RADAR_API_SET_RANGE_ACKNOWLEDGEMENT_PACKET_TYPE;
-    thread_data.protocol_version = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION + 1;
+    thread_data.packet_type_ack = PROVIZIO__RADAR_API_SET_RANGE_ACKNOWLEDGEMENT_PACKET_TYPE;
+    thread_data.packet_type_response = PROVIZIO__RADAR_API_SET_RANGE_RESPONSE_PACKET_TYPE;
+    thread_data.protocol_version_ack = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION + 1;
+    thread_data.protocol_version_response = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
     thread_data.radar_position_id = radar_position_id;
     thread_data.requested_radar_range = range;
-    thread_data.error_code = 0;
+    thread_data.error_code_ack = 0;
+    thread_data.error_code_response = 0;
     pthread_t radar_thread; // NOLINT: Initialized in the next line
     TEST_ASSERT_EQUAL_INT32(
         0, pthread_create(&radar_thread, NULL, &test_provizio_set_radar_range_radar_thread, &thread_data));
     wait_till_test_provizio_set_radar_range_radar_thread_ready(&thread_data);
 
     provizio_set_on_error(&test_provizio_on_error);
-    TEST_ASSERT_EQUAL(PROVIZIO_E_PROTOCOL,
-                      provizio_set_radar_range(radar_position_id, range, port_number, "127.0.0.1"));
-    TEST_ASSERT_EQUAL_STRING("provizio_set_radar_range: Incompatible protocol version", provizio_test_error);
+    provizio_test_error[0] = '\0';
+    provizio_radar_range actual_radar_range = provizio_radar_range_hyper_long;
+    TEST_ASSERT_EQUAL(PROVIZIO_E_PROTOCOL, provizio_set_radar_range(radar_position_id, range, port_number, "127.0.0.1",
+                                                                    &actual_radar_range));
+    TEST_ASSERT_EQUAL(provizio_radar_range_unknown, actual_radar_range);
+    TEST_ASSERT_EQUAL_STRING("provizio_set_radar_range_with_timeout: Incompatible protocol version",
+                             provizio_test_error);
+    provizio_set_on_error(NULL);
+
+    TEST_ASSERT_EQUAL(0, pthread_join(radar_thread, NULL));
+    TEST_ASSERT_EQUAL(0, pthread_mutex_destroy(&mutex));
+}
+
+static void test_provizio_set_radar_range_invalid_response_protocol_version(void)
+{
+    const uint16_t port_number = 20000 + __LINE__ + PROVIZIO__RADAR_API_DEFAULT_PORT;
+    const provizio_radar_position radar_position_id = provizio_radar_position_rear_right;
+    const provizio_radar_range range = provizio_radar_range_long;
+    const provizio_radar_range range_was = provizio_radar_range_ultra_long;
+
+    // Start the test radar thread
+    pthread_mutex_t mutex;
+    TEST_ASSERT_EQUAL(0, pthread_mutex_init(&mutex, NULL));
+    test_provizio_set_radar_range_radar_thread_data thread_data;
+    memset(&thread_data, 0, sizeof(thread_data));
+    thread_data.mutex = &mutex;
+    thread_data.ready_flag = 0;
+    thread_data.port_number = port_number;
+    thread_data.packet_type_ack = PROVIZIO__RADAR_API_SET_RANGE_ACKNOWLEDGEMENT_PACKET_TYPE;
+    thread_data.packet_type_response = PROVIZIO__RADAR_API_SET_RANGE_RESPONSE_PACKET_TYPE;
+    thread_data.protocol_version_ack = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
+    thread_data.protocol_version_response = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION + 1;
+    thread_data.radar_position_id = radar_position_id;
+    thread_data.requested_radar_range = range;
+    thread_data.current_range_was = range_was;
+    thread_data.error_code_ack = 0;
+    thread_data.error_code_response = 0;
+    pthread_t radar_thread; // NOLINT: Initialized in the next line
+    TEST_ASSERT_EQUAL_INT32(
+        0, pthread_create(&radar_thread, NULL, &test_provizio_set_radar_range_radar_thread, &thread_data));
+    wait_till_test_provizio_set_radar_range_radar_thread_ready(&thread_data);
+
+    provizio_set_on_error(&test_provizio_on_error);
+    provizio_test_error[0] = '\0';
+    provizio_radar_range actual_radar_range = provizio_radar_range_hyper_long;
+    TEST_ASSERT_EQUAL(PROVIZIO_E_PROTOCOL, provizio_set_radar_range(radar_position_id, range, port_number, "127.0.0.1",
+                                                                    &actual_radar_range));
+    TEST_ASSERT_EQUAL(range_was, actual_radar_range);
+    TEST_ASSERT_EQUAL_STRING("provizio_set_radar_range_with_timeout: Incompatible protocol version",
+                             provizio_test_error);
     provizio_set_on_error(NULL);
 
     TEST_ASSERT_EQUAL(0, pthread_join(radar_thread, NULL));
@@ -1151,7 +1524,7 @@ static void test_provizio_set_radar_range_invalid_ack_protocol_version(void)
 
 static void test_provizio_set_radar_range_timeout_due_to_incorrect_position(void)
 {
-    const uint16_t port_number = 10017 + PROVIZIO__RADAR_API_SET_RANGE_DEFAULT_PORT;
+    const uint16_t port_number = 20000 + __LINE__ + PROVIZIO__RADAR_API_DEFAULT_PORT;
     const provizio_radar_position radar_position_id = provizio_radar_position_rear_right;
     const provizio_radar_range range = provizio_radar_range_long;
 
@@ -1159,23 +1532,32 @@ static void test_provizio_set_radar_range_timeout_due_to_incorrect_position(void
     pthread_mutex_t mutex;
     TEST_ASSERT_EQUAL(0, pthread_mutex_init(&mutex, NULL));
     test_provizio_set_radar_range_radar_thread_data thread_data;
+    memset(&thread_data, 0, sizeof(thread_data));
     thread_data.mutex = &mutex;
     thread_data.ready_flag = 0;
     thread_data.port_number = port_number;
-    thread_data.packet_type = PROVIZIO__RADAR_API_SET_RANGE_ACKNOWLEDGEMENT_PACKET_TYPE;
-    thread_data.protocol_version = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
+    thread_data.packet_type_ack = PROVIZIO__RADAR_API_SET_RANGE_ACKNOWLEDGEMENT_PACKET_TYPE;
+    thread_data.packet_type_response = PROVIZIO__RADAR_API_SET_RANGE_RESPONSE_PACKET_TYPE;
+    thread_data.protocol_version_ack = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
+    thread_data.protocol_version_response = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
     thread_data.radar_position_id = (uint16_t)(radar_position_id + 1);
     thread_data.requested_radar_range = range;
-    thread_data.error_code = 0;
+    thread_data.error_code_ack = 0;
+    thread_data.error_code_response = 0;
     pthread_t radar_thread; // NOLINT: Initialized in the next line
     TEST_ASSERT_EQUAL_INT32(
         0, pthread_create(&radar_thread, NULL, &test_provizio_set_radar_range_radar_thread, &thread_data));
     wait_till_test_provizio_set_radar_range_radar_thread_ready(&thread_data);
 
     provizio_set_on_error(&test_provizio_on_error);
-    TEST_ASSERT_EQUAL(PROVIZIO_E_TIMEOUT, provizio_set_radar_range(radar_position_id, range, port_number, "127.0.0.1"));
-    TEST_ASSERT_EQUAL_STRING("provizio_set_radar_range: No acknowledgement received, likely due to a connection issue",
-                             provizio_test_error);
+    provizio_test_error[0] = '\0';
+    provizio_radar_range actual_radar_range = provizio_radar_range_hyper_long;
+    TEST_ASSERT_EQUAL(PROVIZIO_E_TIMEOUT, provizio_set_radar_range(radar_position_id, range, port_number, "127.0.0.1",
+                                                                   &actual_radar_range));
+    TEST_ASSERT_EQUAL(provizio_radar_range_unknown, actual_radar_range);
+    TEST_ASSERT_EQUAL_STRING(
+        "provizio_set_radar_range_with_timeout: No acknowledgement received, likely due to a connection issue",
+        provizio_test_error);
     provizio_set_on_error(NULL);
 
     TEST_ASSERT_EQUAL(0, pthread_join(radar_thread, NULL));
@@ -1184,73 +1566,202 @@ static void test_provizio_set_radar_range_timeout_due_to_incorrect_position(void
 
 static void test_provizio_set_radar_range_timeout_due_to_incorrect_range(void)
 {
-    const uint16_t port_number = 10018 + PROVIZIO__RADAR_API_SET_RANGE_DEFAULT_PORT;
+    const uint16_t port_number = 20000 + __LINE__ + PROVIZIO__RADAR_API_DEFAULT_PORT;
     const provizio_radar_position radar_position_id = provizio_radar_position_rear_right;
     const provizio_radar_range range = provizio_radar_range_long;
+    const provizio_radar_range range_was = provizio_radar_range_medium;
 
     // Start the test radar thread
     pthread_mutex_t mutex;
     TEST_ASSERT_EQUAL(0, pthread_mutex_init(&mutex, NULL));
     test_provizio_set_radar_range_radar_thread_data thread_data;
+    memset(&thread_data, 0, sizeof(thread_data));
     thread_data.mutex = &mutex;
     thread_data.ready_flag = 0;
     thread_data.port_number = port_number;
-    thread_data.packet_type = PROVIZIO__RADAR_API_SET_RANGE_ACKNOWLEDGEMENT_PACKET_TYPE;
-    thread_data.protocol_version = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
+    thread_data.packet_type_ack = PROVIZIO__RADAR_API_SET_RANGE_ACKNOWLEDGEMENT_PACKET_TYPE;
+    thread_data.packet_type_response = PROVIZIO__RADAR_API_SET_RANGE_RESPONSE_PACKET_TYPE;
+    thread_data.protocol_version_ack = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
+    thread_data.protocol_version_response = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
     thread_data.radar_position_id = radar_position_id;
     thread_data.requested_radar_range = (uint16_t)(range + 1);
-    thread_data.error_code = 0;
+    thread_data.current_range_was = range_was;
+    thread_data.error_code_ack = 0;
+    thread_data.error_code_response = 0;
     pthread_t radar_thread; // NOLINT: Initialized in the next line
     TEST_ASSERT_EQUAL_INT32(
         0, pthread_create(&radar_thread, NULL, &test_provizio_set_radar_range_radar_thread, &thread_data));
     wait_till_test_provizio_set_radar_range_radar_thread_ready(&thread_data);
 
     provizio_set_on_error(&test_provizio_on_error);
-    TEST_ASSERT_EQUAL(PROVIZIO_E_TIMEOUT, provizio_set_radar_range(radar_position_id, range, port_number, "127.0.0.1"));
-    TEST_ASSERT_EQUAL_STRING("provizio_set_radar_range: No acknowledgement received, likely due to a connection issue",
-                             provizio_test_error);
+    provizio_test_error[0] = '\0';
+    provizio_radar_range actual_radar_range = provizio_radar_range_hyper_long;
+    TEST_ASSERT_EQUAL(PROVIZIO_E_TIMEOUT, provizio_set_radar_range(radar_position_id, range, port_number, "127.0.0.1",
+                                                                   &actual_radar_range));
+    TEST_ASSERT_EQUAL(provizio_radar_range_unknown, actual_radar_range);
+    TEST_ASSERT_EQUAL_STRING(
+        "provizio_set_radar_range_with_timeout: No acknowledgement received, likely due to a connection issue",
+        provizio_test_error);
     provizio_set_on_error(NULL);
 
     TEST_ASSERT_EQUAL(0, pthread_join(radar_thread, NULL));
     TEST_ASSERT_EQUAL(0, pthread_mutex_destroy(&mutex));
 }
 
-static void test_provizio_set_radar_range_unsupported_range(void)
+static void test_provizio_set_radar_range_unsupported_range_ack(void)
 {
-    const uint16_t port_number = 10019 + PROVIZIO__RADAR_API_SET_RANGE_DEFAULT_PORT;
+    const uint16_t port_number = 20000 + __LINE__ + PROVIZIO__RADAR_API_DEFAULT_PORT;
+    // radar_position_id, range
     const provizio_radar_position radar_position_id = provizio_radar_position_rear_right;
-    const provizio_radar_range range = provizio_radar_range_long;
+    const provizio_radar_range range = provizio_radar_range_short;
+    const provizio_radar_range range_was = provizio_radar_range_medium;
 
     // Start the test radar thread
     pthread_mutex_t mutex;
     TEST_ASSERT_EQUAL(0, pthread_mutex_init(&mutex, NULL));
     test_provizio_set_radar_range_radar_thread_data thread_data;
+    memset(&thread_data, 0, sizeof(thread_data));
     thread_data.mutex = &mutex;
     thread_data.ready_flag = 0;
     thread_data.port_number = port_number;
-    thread_data.packet_type = PROVIZIO__RADAR_API_SET_RANGE_ACKNOWLEDGEMENT_PACKET_TYPE;
-    thread_data.protocol_version = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
+    thread_data.packet_type_ack = PROVIZIO__RADAR_API_SET_RANGE_ACKNOWLEDGEMENT_PACKET_TYPE;
+    thread_data.packet_type_response = PROVIZIO__RADAR_API_SET_RANGE_RESPONSE_PACKET_TYPE;
+    thread_data.protocol_version_ack = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
+    thread_data.protocol_version_response = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
     thread_data.radar_position_id = radar_position_id;
     thread_data.requested_radar_range = range;
-    thread_data.error_code = PROVIZIO_E_NOT_PERMITTED;
+    thread_data.current_range_was = range_was;
+    thread_data.error_code_ack = PROVIZIO_E_NOT_SUPPORTED;
+    thread_data.error_code_response = 0;
     pthread_t radar_thread; // NOLINT: Initialized in the next line
     TEST_ASSERT_EQUAL_INT32(
         0, pthread_create(&radar_thread, NULL, &test_provizio_set_radar_range_radar_thread, &thread_data));
     wait_till_test_provizio_set_radar_range_radar_thread_ready(&thread_data);
 
     provizio_set_on_error(&test_provizio_on_error);
-    TEST_ASSERT_EQUAL(PROVIZIO_E_NOT_PERMITTED,
-                      provizio_set_radar_range(radar_position_id, range, port_number, "127.0.0.1"));
-    TEST_ASSERT_EQUAL_STRING("provizio_set_radar_range: Failed to set the requested range", provizio_test_error);
-    provizio_set_on_error(NULL);
+    provizio_test_error[0] = '\0';
+    provizio_radar_range actual_radar_range = provizio_radar_range_hyper_long;
+    TEST_ASSERT_EQUAL(PROVIZIO_E_NOT_SUPPORTED, provizio_set_radar_range(radar_position_id, range, port_number,
+                                                                         "127.0.0.1", &actual_radar_range));
 
     TEST_ASSERT_EQUAL(0, pthread_join(radar_thread, NULL));
     TEST_ASSERT_EQUAL(0, pthread_mutex_destroy(&mutex));
+
+    TEST_ASSERT_EQUAL(range_was, actual_radar_range);
+    TEST_ASSERT_EQUAL_STRING("provizio_set_radar_range_with_timeout: Failed to set the requested range",
+                             provizio_test_error);
+    provizio_set_on_error(NULL);
+}
+
+static void test_provizio_set_radar_range_unsupported_range_response(void)
+{
+    const uint16_t port_number = 20000 + __LINE__ + PROVIZIO__RADAR_API_DEFAULT_PORT;
+    // radar_position_id, range
+    const provizio_radar_position radar_position_id = provizio_radar_position_rear_right;
+    const provizio_radar_range range = provizio_radar_range_short;
+    const provizio_radar_range range_was = provizio_radar_range_medium;
+
+    // Start the test radar thread
+    pthread_mutex_t mutex;
+    TEST_ASSERT_EQUAL(0, pthread_mutex_init(&mutex, NULL));
+    test_provizio_set_radar_range_radar_thread_data thread_data;
+    memset(&thread_data, 0, sizeof(thread_data));
+    thread_data.mutex = &mutex;
+    thread_data.ready_flag = 0;
+    thread_data.port_number = port_number;
+    thread_data.packet_type_ack = PROVIZIO__RADAR_API_SET_RANGE_ACKNOWLEDGEMENT_PACKET_TYPE;
+    thread_data.packet_type_response = PROVIZIO__RADAR_API_SET_RANGE_RESPONSE_PACKET_TYPE;
+    thread_data.protocol_version_ack = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
+    thread_data.protocol_version_response = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
+    thread_data.radar_position_id = radar_position_id;
+    thread_data.requested_radar_range = range;
+    thread_data.current_range_was = range_was;
+    thread_data.error_code_ack = 0;
+    thread_data.error_code_response = PROVIZIO_E_NOT_SUPPORTED;
+    pthread_t radar_thread; // NOLINT: Initialized in the next line
+    TEST_ASSERT_EQUAL_INT32(
+        0, pthread_create(&radar_thread, NULL, &test_provizio_set_radar_range_radar_thread, &thread_data));
+    wait_till_test_provizio_set_radar_range_radar_thread_ready(&thread_data);
+
+    provizio_set_on_error(&test_provizio_on_error);
+    provizio_test_error[0] = '\0';
+    provizio_radar_range actual_radar_range = provizio_radar_range_hyper_long;
+    TEST_ASSERT_EQUAL(PROVIZIO_E_NOT_SUPPORTED, provizio_set_radar_range(radar_position_id, range, port_number,
+                                                                         "127.0.0.1", &actual_radar_range));
+
+    TEST_ASSERT_EQUAL(0, pthread_join(radar_thread, NULL));
+    TEST_ASSERT_EQUAL(0, pthread_mutex_destroy(&mutex));
+
+    TEST_ASSERT_EQUAL(range_was, actual_radar_range);
+    TEST_ASSERT_EQUAL_STRING("provizio_set_radar_range_with_timeout: Failed to set the requested range",
+                             provizio_test_error);
+    provizio_set_on_error(NULL);
+}
+
+static void test_provizio_request_current_range(void)
+{
+    const uint16_t port_number = 20000 + __LINE__ + PROVIZIO__RADAR_API_DEFAULT_PORT;
+    // radar_position_id, range
+    const provizio_radar_position radar_position_id = provizio_radar_position_rear_right;
+    const provizio_radar_range requested_radar_range = provizio_radar_range_unknown;
+    const provizio_radar_range range_was = provizio_radar_range_medium;
+
+    // Start the test radar thread
+    pthread_mutex_t mutex;
+    TEST_ASSERT_EQUAL(0, pthread_mutex_init(&mutex, NULL));
+    test_provizio_set_radar_range_radar_thread_data thread_data;
+    memset(&thread_data, 0, sizeof(thread_data));
+    thread_data.mutex = &mutex;
+    thread_data.ready_flag = 0;
+    thread_data.port_number = port_number;
+    thread_data.packet_type_ack = PROVIZIO__RADAR_API_SET_RANGE_ACKNOWLEDGEMENT_PACKET_TYPE;
+    thread_data.packet_type_response = PROVIZIO__RADAR_API_SET_RANGE_RESPONSE_PACKET_TYPE;
+    thread_data.protocol_version_ack = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
+    thread_data.protocol_version_response = PROVIZIO__RADAR_API_RANGE_PROTOCOL_VERSION;
+    thread_data.radar_position_id = radar_position_id;
+    thread_data.requested_radar_range = requested_radar_range;
+    thread_data.current_range_was = range_was;
+    thread_data.error_code_ack = PROVIZIO_E_SKIPPED;
+    thread_data.error_code_response = 0;
+    pthread_t radar_thread; // NOLINT: Initialized in the next line
+    TEST_ASSERT_EQUAL_INT32(
+        0, pthread_create(&radar_thread, NULL, &test_provizio_set_radar_range_radar_thread, &thread_data));
+    wait_till_test_provizio_set_radar_range_radar_thread_ready(&thread_data);
+
+    provizio_set_on_error(&test_provizio_on_error);
+    provizio_test_error[0] = '\0';
+    provizio_radar_range current_radar_range = provizio_radar_range_hyper_long;
+    TEST_ASSERT_EQUAL(
+        0, provizio_request_current_range(radar_position_id, port_number, "127.0.0.1", &current_radar_range));
+
+    TEST_ASSERT_EQUAL(0, pthread_join(radar_thread, NULL));
+    TEST_ASSERT_EQUAL(0, pthread_mutex_destroy(&mutex));
+
+    TEST_ASSERT_EQUAL(range_was, current_radar_range);
+    // Requesting the range works via "setting" the range to unknown and shouldn't produce any error
+    TEST_ASSERT_EQUAL_STRING("", provizio_test_error);
+    provizio_set_on_error(NULL);
+}
+
+static void test_provizio_request_current_range_null(void)
+{
+    const uint16_t port_number = 20000 + __LINE__ + PROVIZIO__RADAR_API_DEFAULT_PORT;
+    // radar_position_id, range
+    const provizio_radar_position radar_position_id = provizio_radar_position_rear_right;
+
+    provizio_set_on_error(&test_provizio_on_error);
+    provizio_test_error[0] = '\0';
+    TEST_ASSERT_EQUAL(PROVIZIO_E_ARGUMENT,
+                      provizio_request_current_range(radar_position_id, port_number, "127.0.0.1", NULL));
+
+    TEST_ASSERT_EQUAL_STRING("provizio_request_current_range: out_current_radar_range argument can't be NULL",
+                             provizio_test_error);
+    provizio_set_on_error(NULL);
 }
 
 static void test_duplicated_packets(void)
 {
-    const uint16_t port_number = 10020 + PROVIZIO__RADAR_API_SET_RANGE_DEFAULT_PORT;
+    const uint16_t port_number = 20000 + __LINE__ + PROVIZIO__RADAR_API_DEFAULT_PORT;
     const uint32_t frame_index = 11;
     const uint64_t timestamp = 0x0123456789abcdef;
     const uint16_t radar_position_id = provizio_radar_position_front_left;
@@ -1312,15 +1823,24 @@ int provizio_run_test_core(void)
     RUN_TEST(test_receive_radar_point_cloud_timeout_fails);
     RUN_TEST(test_provizio_radar_point_cloud_api_contexts_receive_packet_fails_as_not_connected);
     RUN_TEST(test_provizio_radar_point_cloud_api_close_fails_as_not_connected);
+    RUN_TEST(test_provizio_set_radar_range_ok_already_set);
     RUN_TEST(test_provizio_set_radar_range_ok);
     RUN_TEST(test_provizio_set_radar_range_broadcasting_ok);
-    RUN_TEST(test_provizio_set_radar_range_invalid_range);
-    RUN_TEST(test_provizio_set_radar_range_timeout);
+    RUN_TEST(test_provizio_set_radar_range_unknown_range);
+    RUN_TEST(test_provizio_set_radar_range_huge_timeout);
+    RUN_TEST(test_provizio_set_radar_range_ack_timeout);
+    RUN_TEST(test_provizio_set_radar_range_response_timeout);
     RUN_TEST(test_provizio_set_radar_range_invalid_ack_packet_type);
+    RUN_TEST(test_provizio_set_radar_range_invalid_response_packet_type);
+    RUN_TEST(test_provizio_set_radar_range_response_packet_type_from_previous_request);
     RUN_TEST(test_provizio_set_radar_range_invalid_ack_protocol_version);
+    RUN_TEST(test_provizio_set_radar_range_invalid_response_protocol_version);
     RUN_TEST(test_provizio_set_radar_range_timeout_due_to_incorrect_position);
     RUN_TEST(test_provizio_set_radar_range_timeout_due_to_incorrect_range);
-    RUN_TEST(test_provizio_set_radar_range_unsupported_range);
+    RUN_TEST(test_provizio_set_radar_range_unsupported_range_ack);
+    RUN_TEST(test_provizio_set_radar_range_unsupported_range_response);
+    RUN_TEST(test_provizio_request_current_range);
+    RUN_TEST(test_provizio_request_current_range_null);
     RUN_TEST(test_duplicated_packets);
 
     return UNITY_END();

--- a/test/c_99/src/test_radar_point_cloud.c
+++ b/test/c_99/src/test_radar_point_cloud.c
@@ -222,11 +222,12 @@ static void test_provizio_radar_point_cloud_packet_size(void)
                              provizio_radar_point_cloud_packet_size(&header));
 
     provizio_set_protocol_field_uint16_t(&header.num_points_in_packet, 2);
-    TEST_ASSERT_EQUAL_UINT64(sizeof(header) + sizeof(provizio_radar_point) * 2,
+    TEST_ASSERT_EQUAL_UINT64(sizeof(header) + (sizeof(provizio_radar_point) * 2),
                              provizio_radar_point_cloud_packet_size(&header));
 
     provizio_set_protocol_field_uint16_t(&header.num_points_in_packet, PROVIZIO__MAX_RADAR_POINTS_PER_UDP_PACKET);
-    TEST_ASSERT_EQUAL_UINT64(sizeof(header) + sizeof(provizio_radar_point) * PROVIZIO__MAX_RADAR_POINTS_PER_UDP_PACKET,
+    TEST_ASSERT_EQUAL_UINT64(sizeof(header) +
+                                 (sizeof(provizio_radar_point) * PROVIZIO__MAX_RADAR_POINTS_PER_UDP_PACKET),
                              provizio_radar_point_cloud_packet_size(&header));
 
     provizio_set_on_warning(&test_provizio_on_warning);
@@ -446,7 +447,7 @@ static void test_provizio_radar_point_cloud_api_context_assign(void)
 
     // Reassign to another position once assigned - Fails
     provizio_set_on_error(&test_provizio_on_error);
-    TEST_ASSERT_EQUAL_INT32(PROVIZIO_E_NOT_PERMITTED,
+    TEST_ASSERT_EQUAL_INT32(PROVIZIO_E_NOT_SUPPORTED,
                             provizio_radar_point_cloud_api_context_assign(&api_context, radar_position_id + 1));
     TEST_ASSERT_EQUAL_STRING("provizio_radar_point_cloud_api_context_assign: already assigned", provizio_test_error);
     provizio_set_on_error(NULL);

--- a/test/cpp_14/src/smoketest.cpp
+++ b/test/cpp_14/src/smoketest.cpp
@@ -107,7 +107,7 @@ int main(int argc, char *argv[])
         std::atomic<bool> finish{false};
         std::mutex exception_in_thread_mutex;
         std::string exception_in_send_thread;
-        std::thread send_messages_thread{[&]() {
+        std::thread send_messages_thread{[&]() { // LCOV_EXCL_LINE: False positive in some versions of gcov/lcov
             try
             {
                 const auto send_socket = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);


### PR DESCRIPTION
To achieve more reliable range setting logic