### PR TITLE
APT-10272: Entities API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,7 +307,9 @@ endif(NOT LINMATH_DOWNLOAD_STATUS EQUAL 0)
 add_library(
   provizio_radar_api_core STATIC
   src/common.c
+  src/quaternion.c
   src/socket.c
+  src/entities.c
   src/radar_point_cloud.c
   src/radar_points_accumulation.c
   src/radar_points_accumulation_filters.c

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The official C library providing API for communicating with Provizio radars.
 
 ### Building and Linking
 
-**provizio_radar_api_core** is a static C Library built with CMake 3.1.0+.
+**provizio_radar_api_core** is a static C Library built with CMake 3.10+.
 There is a number of options to use it in your project. Some of the options:
 
 1. For [CMake](https://cmake.org/)-based C/C++ projects, you may use `ExternalProject_Add`, f.e.
@@ -1163,27 +1163,28 @@ Entities packets are broadcast alongside point clouds on the same UDP port. They
 `packet_type = PROVIZIO__RADAR_API_ENTITIES_PACKET_TYPE (5)` and transport up to
 `PROVIZIO__MAX_RADAR_ENTITIES_PER_UDP_PACKET` objects per UDP packet:
 
-| Field                                   | Size (bytes) | Data Type | Description                                                                                                    |
-| --------------------------------------- | ------------ | --------- | -------------------------------------------------------------------------------------------------------------- |
-| packet_type                             | 2            | uint16_t  | Always = 5                                                                                                     |
-| protocol_version                        | 2            | uint16_t  | Currently = 1                                                                                                  |
-| frame_index                             | 4            | uint32_t  | 0-based entities frame index                                                                                   |
-| timestamp                               | 8            | uint64_t  | Nanoseconds since Unix Epoch                                                                                   |
-| radar_position_id                       | 2            | uint16_t  | Either one of `provizio_radar_position` enum values or a custom id                                             |
-| total_entities_in_frame                 | 2            | uint16_t  | Total number of entities in the frame                                                                          |
-| num_entities_in_packet                  | 2            | uint16_t  | Number of entities inside this packet                                                                          |
-| radar_range                             | 2            | uint16_t  | One of `provizio_radar_range` enum values                                                                      |
-| entity_i: entity_id                     | 4            | uint32_t  | Unique identifier of the entity (may persist across frames)                                                    |
-| entity_i: *_meters                      | 12           | float     | Radar-relative position (X forward, Y left, Z up)                                                              |
-| entity_i: radar_relative_radial_velocity_m_s  | 4      | float     | Radar-relative radial velocity along the forward axis                                                          |
-| entity_i: ground_relative_radial_velocity_m_s | 4      | float     | Ground-relative forward projection (NaN if unavailable)                                                        |
-| entity_i: orientation                   | 16           | float     | Quaternion `(w, x, y, z)` describing orientation                                                               |
-| entity_i: entity_class                  | 1            | uint8_t   | One of `provizio_entity_class` enum values (pedestrian, car, etc.)                                             |
-| entity_i: entity_confidence             | 1            | uint8_t   | Confidence the entity exists (0–255, higher means more confident)                                              |
-| entity_i: entity_class_confidence       | 1            | uint8_t   | Confidence the entity class is correct (0–255)                                                                 |
-| entity_i: reserved                      | 1            | uint8_t   | Reserved for future use                                                                                        |
-| ...                                     |              |           | Repeated for each entity in the packet                                                                         |
-| **Total**                               | **24 + 44 * num_entities_in_packet** |           | Never exceeds 1472 bytes                                                                                       |
+| Field                                            | Size (bytes) | Data Type | Description                                                           |
+| ---------------------------------------------    | ------------ | --------- | --------------------------------------------------------------------- |
+| packet_type                                      | 2            | uint16_t  | Always = 5                                                            |
+| protocol_version                                 | 2            | uint16_t  | Currently = 1                                                         |
+| frame_index                                      | 4            | uint32_t  | 0-based entities frame index                                          |
+| timestamp                                        | 8            | uint64_t  | Nanoseconds since Unix Epoch                                          |
+| radar_position_id                                | 2            | uint16_t  | Either one of `provizio_radar_position` enum values or a custom id    |
+| total_entities_in_frame                          | 2            | uint16_t  | Total number of entities in the frame                                 |
+| num_entities_in_packet                           | 2            | uint16_t  | Number of entities inside this packet                                 |
+| radar_range                                      | 2            | uint16_t  | One of `provizio_radar_range` enum values                             |
+| entity_i: entity_id                              | 4            | uint32_t  | Unique identifier of the entity (may persist across frames)           |
+| entity_i: *_meters                               | 12           | float     | Radar-relative position (X forward, Y left, Z up)                     |
+| entity_i: radar_relative_radial_velocity_m_s     | 4            | float     | Radar-relative radial velocity along the forward axis                 |
+| entity_i: ground_relative_radial_velocity_m_s    | 4            | float     | Ground-relative forward projection (NaN if unavailable)               |
+| entity_i: orientation                            | 16           | float     | Quaternion `(w, x, y, z)` describing orientation                      |
+| entity_i: size                                   | 12           | float     | Bounding box size `(x, y, z)` in meters                               |
+| entity_i: entity_class                           | 1            | uint8_t   | One of `provizio_entity_class` enum values (pedestrian, car, etc.)    |
+| entity_i: entity_confidence                      | 1            | uint8_t   | Confidence the entity exists (0–255, higher means more confident)     |
+| entity_i: entity_class_confidence                | 1            | uint8_t   | Confidence the entity class is correct (0–255)                        |
+| entity_i: reserved                               | 1            | uint8_t   | Reserved for future use                                               |
+| ...                                              |              |           | Repeated for each entity in the packet                                |
+| **Total** | **24 + 56 * num_entities_in_packet** |                          | Never exceeds 1472 bytes                                              |
 
 Entities are gathered into `provizio_radar_entities_frame` objects internally (same frame/timestamp metadata, plus a
 buffer with up to `PROVIZIO__MAX_RADAR_ENTITIES_PER_FRAME` padded entries) before being dispatched to your callback.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@
       - [Example of Point Clouds Accumulation](#example-of-point-clouds-accumulation)
       - [Accumulation Initialization](#accumulation-initialization)
       - [Storing Localization Information in provizio\_enu\_fix](#storing-localization-information-in-provizio_enu_fix)
+    - [Receiving Radar Entities](#receiving-radar-entities)
+      - [Live UDP (Entities)](#live-udp-entities)
+      - [Replay or Custom Transport (Entities)](#replay-or-custom-transport-entities)
       - [Accumulating Point Clouds](#accumulating-point-clouds)
       - [Accumulation Filters](#accumulation-filters)
       - [Retrieving Accumulated Points](#retrieving-accumulated-points)
@@ -21,6 +24,7 @@
     - [Shutting Down](#shutting-down)
   - [UDP Protocol](#udp-protocol)
     - [Radar Point Clouds](#radar-point-clouds)
+    - [Radar Entities](#radar-entities)
     - [Radar Ranges](#radar-ranges)
 
 The official C library providing API for communicating with Provizio radars.
@@ -195,7 +199,7 @@ Optionally, a number of CMake arguments can be specified when configuring the li
     * @param user_data Custom argument to be passed to the callback, may be NULL
     * @param context The provizio_radar_point_cloud_api_context object to initialize
     *
-    * @warning radar_position_id of all packets handled by this context must be same
+    * @note radar_position_id of all packets handled by this context must be same
     */
     provizio_radar_point_cloud_api_context_init(&your_radar_point_cloud_callback, your_callback_data, &api_context);
     ```
@@ -228,6 +232,47 @@ Optionally, a number of CMake arguments can be specified when configuring the li
     provizio_radar_point_cloud_api_contexts_init(&your_radar_point_cloud_callback, your_callback_data, api_contexts, num_contexts);
     ```
 
+5. Create and initialize a `provizio_radar_entities_api_context` (or several of them) if you also want to receive high-level radar entities:
+
+    ```C
+    // Somewhere in a header
+
+    void your_radar_entities_callback(const provizio_radar_entities_frame *entities_frame,
+                                      provizio_radar_entities_api_context *context);
+
+    // In a C/C++ function
+
+    void *your_entities_callback_data = <your optional callback data, may be NULL>;
+
+    provizio_radar_entities_api_context entities_context;
+
+    /**
+    * @brief Initializes a provizio_radar_entities_api_context object to handle a single radar
+    *
+    * @param callback Function to be called on receiving a complete or partial radar entities frame
+    * @param user_data Custom argument to be passed to the callback, may be NULL
+    * @param context The provizio_radar_entities_api_context object to initialize
+    */
+    provizio_radar_entities_api_context_init(&your_radar_entities_callback, your_entities_callback_data,
+                                             &entities_context);
+    ```
+
+    or
+
+    ```C
+    const uint16_t num_entities_contexts = <your max number of radars on the same UDP port>;
+    void *your_entities_callback_data = <your optional callback data, may be NULL>;
+
+    provizio_radar_entities_api_context *entities_contexts = (provizio_radar_entities_api_context *)malloc(
+        sizeof(provizio_radar_entities_api_context) * num_entities_contexts);
+
+    /**
+    * @brief Initializes multiple provizio_radar_entities_api_context objects to handle packets from multiple radars
+    */
+    provizio_radar_entities_api_contexts_init(&your_radar_entities_callback, your_entities_callback_data,
+                                              entities_contexts, num_entities_contexts);
+    ```
+
 ### Connection
 
 When the API is used in live UDP mode, [initialization](#initialization) is followed by connection.
@@ -254,12 +299,15 @@ When the API is used in live UDP mode, [initialization](#initialization) is foll
      * returning a successful result
      * @param radar_point_cloud_api_context Initialized provizio_radar_point_cloud_api_context to handle point cloud packets
      * (may be NULL to skip any point cloud packets)
+     * @param radar_entities_api_context Initialized provizio_radar_entities_api_context to handle entities packets (may
+     * be NULL to skip any entities packets)
      * @param out_connection A provizio_radar_api_connection to store the connection handle
      * @return 0 if received successfully, PROVIZIO_E_TIMEOUT if timed out, other error value if failed for another reason
      *
      * @note The connection has to be eventually closed with provizio_close_radar_connection
      */
-    int32_t status = provizio_open_radar_connection(udp_port, receive_timeout_ns, check_connection, &api_context, &connection);
+    int32_t status = provizio_open_radar_connection(udp_port, receive_timeout_ns, check_connection, &api_context,
+                                                    &entities_context, &connection);
     ```
 
 - Multiple radars on the same UDP port use case:
@@ -286,12 +334,17 @@ When the API is used in live UDP mode, [initialization](#initialization) is foll
     * cloud packets (may be NULL to skip any point cloud packets)
     * @param num_radar_point_cloud_api_contexts Number of radar_point_cloud_api_contexts, i.e. max numbers of radars to
     * handle (may be 0 to skip any point cloud packets)
+    * @param radar_entities_api_contexts Array of initialized provizio_radar_entities_api_context to handle entities
+    * packets (may be NULL to skip any entities packets)
+    * @param num_radar_entities_api_contexts Number of radar_entities_api_contexts, i.e. max numbers of radars to handle
+    * (may be 0 to skip any entities packets)
     * @param out_connection A provizio_radar_api_connection to store the connection handle
     * @return 0 if received successfully, PROVIZIO_E_TIMEOUT if timed out, other error value if failed for another reason
     *
     * @note The connection has to be eventually closed with provizio_close_radars_connection
     */
-    int32_t status = provizio_open_radars_connection(udp_port, receive_timeout_ns, check_connection, api_contexts, num_contexts, &connection);
+    int32_t status = provizio_open_radars_connection(udp_port, receive_timeout_ns, check_connection, api_contexts,
+                                                     num_contexts, entities_contexts, num_entities_contexts, &connection);
     ```
 
 ### Receiving Point Clouds
@@ -315,7 +368,7 @@ void your_radar_point_cloud_callback(const provizio_radar_point_cloud *point_clo
     // 0-based radar frame index
     const uint32_t frame_index = point_cloud->frame_index;
 
-    // Time of the frame capture measured in absolute number of nanoseconds since the start of the GPS Epoch (midnight on Jan 6, 1980)
+    // Time of the frame capture measured in number of nanoseconds since the Unix Epoch
     const uint64_t timestamp = point_cloud->timestamp;
 
     // Either one of provizio_radar_position enum values or a custom position id
@@ -394,7 +447,7 @@ There are a few options for this:
     * @return 0 in case the packet was handled successfully, PROVIZIO_E_SKIPPED in case the packet was skipped as obsolete,
     * other error code in case of another error
     *
-    * @warning radar_position_id of all packets handled by this context must be same (returns an error otherwise)
+    * @note radar_position_id of all packets handled by this context must be same (returns an error otherwise)
     */
     int32_t status = provizio_handle_radar_point_cloud_packet(&context, packet, packet_size);
     ```
@@ -435,7 +488,7 @@ There are a few options for this:
     * a provizio_radar_point_cloud_packet, other error code if it's a provizio_radar_point_cloud_packet but its handling
     * failed for another reason
     *
-    * @warning if it's a provizio_radar_point_cloud_packet, radar_position_id of all packets handled by this context must
+    * @note if it's a provizio_radar_point_cloud_packet, radar_position_id of all packets handled by this context must
     * be same (returns an error otherwise)
     */
     int32_t status = provizio_handle_possible_radar_point_cloud_packet(&context, payload, payload_size);
@@ -566,6 +619,99 @@ radar_fix.position.east_meters = float_east_meters;
 radar_fix.position.north_meters = float_north_meters;
 radar_fix.position.up_meters = float_up_meters;
 ```
+
+### Receiving Radar Entities
+
+Radar entities are higher-level objects (pedestrians, vehicles, etc.) derived from radar detections. Their handling
+closely mirrors point cloud reception: packets may be missing or reordered and entity frames can therefore be incomplete.
+Like point clouds, callbacks are invoked in monotonically increasing `frame_index` order and `timestamp` values never
+decrease.
+
+```C
+void your_radar_entities_callback(const provizio_radar_entities_frame *entities_frame,
+                                  provizio_radar_entities_api_context *context)
+{
+    const provizio_radar_position radar_position_id = (provizio_radar_position)context->radar_position_id;
+    my_custom_user_data_type *user_data = (my_custom_user_data_type *)context->user_data;
+
+    const uint32_t frame_index = entities_frame->frame_index;
+    const uint64_t timestamp = entities_frame->timestamp;
+    const uint16_t num_entities_expected = entities_frame->num_entities_expected;
+    const uint16_t num_entities_received = entities_frame->num_entities_received;
+    const provizio_radar_range radar_range = (provizio_radar_range)entities_frame->radar_range;
+
+    if (num_entities_received < num_entities_expected)
+    {
+        // Still missing one or more packets for this frame
+    }
+    else
+    {
+        assert(num_entities_received == num_entities_expected);
+    }
+
+    for (uint16_t i = 0; i < num_entities_received; ++i)
+    {
+        const provizio_radar_entity *entity = &entities_frame->radar_entities[i];
+
+        const uint32_t entity_id = entity->entity_id;
+        const float x_meters = entity->x_meters;   // Forward, radar relative
+        const float y_meters = entity->y_meters;   // Left, radar relative
+        const float z_meters = entity->z_meters;   // Up, radar relative
+        const float radar_relative_velocity = entity->radar_relative_radial_velocity_m_s;
+        const float ground_relative_velocity = entity->ground_relative_radial_velocity_m_s;
+        const provizio_quaternion orientation = entity->orientation;
+        const uint8_t entity_class = entity->entity_class;
+        const uint8_t entity_confidence = entity->entity_confidence;
+
+        // Use the entity data as needed
+        (void)entity_id;
+        (void)radar_relative_velocity;
+        (void)ground_relative_velocity;
+        (void)orientation;
+        (void)entity_class;
+        (void)entity_confidence;
+    }
+}
+```
+
+#### Live UDP (Entities)
+
+`provizio_radar_api_receive_packet` automatically dispatches entities packets to the `provizio_radar_entities_api_context`
+instances that you supplied when opening the connection (if any). The callback may therefore be invoked multiple times per
+call, up to `PROVIZIO__RADAR_ENTITIES_API_CONTEXT_IMPL_FRAMES_BEING_RECEIVED_COUNT` (2 by default).
+
+#### Replay or Custom Transport (Entities)
+
+You can reuse the same helper APIs as with point clouds, but the entities equivalents should be called:
+
+- Single-radar:
+
+    ```C
+    const provizio_radar_entities_packet *packet = your_packet;
+    const size_t packet_size = your_packet_size;
+
+    int32_t status = provizio_handle_entities_packet(&entities_context, (provizio_radar_entities_packet *)packet,
+                                                     packet_size);
+    ```
+
+- Multiple radars:
+
+    ```C
+    int32_t status = provizio_handle_radars_entities_packet(entities_contexts, num_entities_contexts,
+                                                            (provizio_radar_entities_packet *)packet, packet_size);
+    ```
+
+- Unknown packet type (e.g. logs/replay):
+
+    ```C
+    int32_t status = provizio_handle_possible_radar_entities_packet(&entities_context, payload, payload_size);
+    // or
+    int32_t status = provizio_handle_possible_radars_entities_packet(entities_contexts, num_entities_contexts, payload,
+                                                                     payload_size);
+    ```
+
+All of the above functions obey the same error semantics (`0` success, `PROVIZIO_E_SKIPPED` when filtered out, protocol
+errors otherwise) as their point cloud counterparts.
 
 #### Accumulating Point Clouds
 
@@ -888,7 +1034,7 @@ and `provizio_set_radar_range_with_timeout`:
  * @param udp_port UDP port to send change range message, by default = PROVIZIO__RADAR_API_SET_RANGE_DEFAULT_PORT
  * (if 0)
  * @param ipv4_address IP address to send change range message, in the standard IPv4 dotted decimal notation. By default
- * = "255.255.255.255" - broadcast (if NULL)
+ * = "255.255.255.255" - broadcast (if NULL). Note: broadcasting to 255.255.255.255 may be unsupported in macOS.
  * @param out_actual_radar_range If not NULL, actual radar range after the operation will be stored here if received
  * from the radar (will be provizio_radar_range_unknown otherwise)
  * @return 0 if set successfully, PROVIZIO_E_TIMEOUT if timed out, other error value if failed for another reason
@@ -909,7 +1055,7 @@ PROVIZIO__EXTERN_C int32_t provizio_set_radar_range(provizio_radar_position rada
  * @param udp_port UDP port to send change range message, by default = PROVIZIO__RADAR_API_SET_RANGE_DEFAULT_PORT
  * (if 0)
  * @param ipv4_address IP address to send change range message, in the standard IPv4 dotted decimal notation. By default
- * = "255.255.255.255" - broadcast (if NULL)
+ * = "255.255.255.255" - broadcast (if NULL). Note: broadcasting to 255.255.255.255 may be unsupported in macOS.
  * @param out_actual_radar_range If not NULL, actual radar range after the operation will be stored here if received
  * from the radar (will be provizio_radar_range_unknown otherwise)
  * @param timeout_ns The operation timeout (nanoseconds)
@@ -933,7 +1079,7 @@ You can also request the current radar range (instead of waiting for a point clo
  * @param udp_port UDP port to send the request message, by default = PROVIZIO__RADAR_API_REQUEST_RANGE_DEFAULT_PORT
  * (if 0)
  * @param ipv4_address IP address to send request range message, in the standard IPv4 dotted decimal notation. By
- * default = "255.255.255.255" - broadcast (if NULL)
+ * default = "255.255.255.255" - broadcast (if NULL). Note: broadcasting to 255.255.255.255 may be unsupported in macOS.
  * @param out_current_radar_range Current radar range is stored here if successful (will be provizio_radar_range_unknown
  * otherwise)
  * @return 0 if received successfully, PROVIZIO_E_TIMEOUT if timed out, other error value if failed for another reason
@@ -996,7 +1142,7 @@ Each packet has the following structure (all fields use network bytes order when
 | packet_type                                           | 2                                    | uint16_t  | Always = 1, can't change even on protocol updates                                                                               |
 | protocol_version                                      | 2                                    | uint16_t  | Currently = 2, to be incremented on any protocol changes (used for backward compatibility)                                      |
 | frame_index                                           | 4                                    | uint32_t  | 0-based frame index (resets back to 0 if ever exceeds 4294967295)                                                               |
-| timestamp                                             | 8                                    | uint64_t  | Time of the frame capture measured in absolute number of nanoseconds since the start of the GPS Epoch (midnight on Jan 6, 1980) |
+| timestamp                                             | 8                                    | uint64_t  | Time of the frame capture measured in number of nanoseconds since the Unix Epoch |
 | radar_position_id                                     | 2                                    | uint16_t  | Either one of provizio_radar_position enum values or a custom position id                                                       |
 | total_points_in_frame                                 | 2                                    | uint16_t  | Total number of points in the frame #frame_index, never exceeds 65535                                                           |
 | num_points_in_packet                                  | 2                                    | uint16_t  | Number of points in the current packet, never exceeds (1472 - 24) / 24                                                          |
@@ -1010,6 +1156,37 @@ Each packet has the following structure (all fields use network bytes order when
 | point_1: ...                                          |                                      |           |                                                                                                                                 |
 | ...                                                   |                                      |           |                                                                                                                                 |
 | **Total**                                             | **24 + (24 * num_points_in_packet)** |           | Never exceeds 1472 bytes                                                                                                        |
+
+### Radar Entities
+
+Entities packets are broadcast alongside point clouds on the same UDP port. They reuse the same protocol header with
+`packet_type = PROVIZIO__RADAR_API_ENTITIES_PACKET_TYPE (5)` and transport up to
+`PROVIZIO__MAX_RADAR_ENTITIES_PER_UDP_PACKET` objects per UDP packet:
+
+| Field                                   | Size (bytes) | Data Type | Description                                                                                                    |
+| --------------------------------------- | ------------ | --------- | -------------------------------------------------------------------------------------------------------------- |
+| packet_type                             | 2            | uint16_t  | Always = 5                                                                                                     |
+| protocol_version                        | 2            | uint16_t  | Currently = 1                                                                                                  |
+| frame_index                             | 4            | uint32_t  | 0-based entities frame index                                                                                   |
+| timestamp                               | 8            | uint64_t  | Nanoseconds since Unix Epoch                                                                                   |
+| radar_position_id                       | 2            | uint16_t  | Either one of `provizio_radar_position` enum values or a custom id                                             |
+| total_entities_in_frame                 | 2            | uint16_t  | Total number of entities in the frame                                                                          |
+| num_entities_in_packet                  | 2            | uint16_t  | Number of entities inside this packet                                                                          |
+| radar_range                             | 2            | uint16_t  | One of `provizio_radar_range` enum values                                                                      |
+| entity_i: entity_id                     | 4            | uint32_t  | Unique identifier of the entity (may persist across frames)                                                    |
+| entity_i: *_meters                      | 12           | float     | Radar-relative position (X forward, Y left, Z up)                                                              |
+| entity_i: radar_relative_radial_velocity_m_s  | 4      | float     | Radar-relative radial velocity along the forward axis                                                          |
+| entity_i: ground_relative_radial_velocity_m_s | 4      | float     | Ground-relative forward projection (NaN if unavailable)                                                        |
+| entity_i: orientation                   | 16           | float     | Quaternion `(w, x, y, z)` describing orientation                                                               |
+| entity_i: entity_class                  | 1            | uint8_t   | One of `provizio_entity_class` enum values (pedestrian, car, etc.)                                             |
+| entity_i: entity_confidence             | 1            | uint8_t   | Confidence the entity exists (0–255, higher means more confident)                                              |
+| entity_i: entity_class_confidence       | 1            | uint8_t   | Confidence the entity class is correct (0–255)                                                                 |
+| entity_i: reserved                      | 1            | uint8_t   | Reserved for future use                                                                                        |
+| ...                                     |              |           | Repeated for each entity in the packet                                                                         |
+| **Total**                               | **24 + 44 * num_entities_in_packet** |           | Never exceeds 1472 bytes                                                                                       |
+
+Entities are gathered into `provizio_radar_entities_frame` objects internally (same frame/timestamp metadata, plus a
+buffer with up to `PROVIZIO__MAX_RADAR_ENTITIES_PER_FRAME` padded entries) before being dispatched to your callback.
 
 ### Radar Ranges
 

--- a/include/provizio/quaternion.h
+++ b/include/provizio/quaternion.h
@@ -1,0 +1,67 @@
+// Copyright 2025 Provizio Ltd.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PROVIZIO_QUATERNION
+#define PROVIZIO_QUATERNION
+
+#include "provizio/common.h"
+
+/**
+ * @brief Represents a quaternion, normally a unit quaternion storing a spatial orientation.
+ *
+ * @see https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation
+ * @see provizio_quaternion_set_identity
+ * @see provizio_quaternion_set_euler_angles
+ * @see provizio_quaternion_is_valid_rotation
+ */
+typedef struct provizio_quaternion
+{
+    float w;
+    float x;
+    float y;
+    float z;
+} provizio_quaternion;
+
+/**
+ * @brief Sets the specified quaternion to identity, i.e. east-looking orientation.
+ *
+ * @param out_quaternion The quaternion to be set.
+ * @see provizio_quaternion
+ */
+PROVIZIO__EXTERN_C void provizio_quaternion_set_identity(provizio_quaternion *out_quaternion);
+
+/**
+ * @brief Sets the specified quaternion from the specified Euler angles, as applied in this order: z, y, x (yaw, pitch,
+ * roll).
+ *
+ * @param x_rad Rotation around the forward (roll) or east axis, depending on the context (radians).
+ * @param y_rad Rotation around the left (pitch) or north axis, depending on the context (radians).
+ * @param z_rad Rotation around the up (yaw) axis (radians).
+ * @param out_quaternion The rotation/orientation quaternion to be set.
+ * @see https://en.wikipedia.org/wiki/Euler_angles
+ * @see provizio_quaternion
+ * @see provizio_quaternion_set_identity
+ */
+PROVIZIO__EXTERN_C void provizio_quaternion_set_euler_angles(float x_rad, float y_rad, float z_rad,
+                                                             provizio_quaternion *out_quaternion);
+
+/**
+ * @brief Checks if the specified quaternion is a valid rotation/orientation quaternion.
+ *
+ * @param quaternion The quaternion to be checked.
+ * @return Non-zero if valid, zero otherwise.
+ * @see provizio_quaternion
+ */
+PROVIZIO__EXTERN_C uint8_t provizio_quaternion_is_valid_rotation(const provizio_quaternion *quaternion);
+
+#endif // PROVIZIO_QUATERNION

--- a/include/provizio/radar_api/common.h
+++ b/include/provizio/radar_api/common.h
@@ -22,6 +22,7 @@
 #define PROVIZIO__RADAR_API_SET_RANGE_PACKET_TYPE ((uint16_t)2)
 #define PROVIZIO__RADAR_API_SET_RANGE_ACKNOWLEDGEMENT_PACKET_TYPE ((uint16_t)3)
 #define PROVIZIO__RADAR_API_SET_RANGE_RESPONSE_PACKET_TYPE ((uint16_t)4)
+#define PROVIZIO__RADAR_API_ENTITIES_PACKET_TYPE ((uint16_t)5)
 
 // Use packed structs intended to be sent for binary compatibility across all CPUs
 #pragma pack(push, 1)

--- a/include/provizio/radar_api/core.h
+++ b/include/provizio/radar_api/core.h
@@ -16,6 +16,7 @@
 #define PROVIZIO_RADAR_API_CORE
 
 #include "provizio/common.h"
+#include "provizio/radar_api/entities.h"
 #include "provizio/radar_api/errno.h"
 #include "provizio/radar_api/radar_point_cloud.h"
 #include "provizio/radar_api/radar_points_accumulation.h"
@@ -23,10 +24,11 @@
 #include "provizio/socket.h"
 #include "provizio/util.h"
 
-#define PROVIZIO__RADAR_API_DEFAULT_PORT ((uint16_t)7769U)
+#define PROVIZIO__RADAR_API_DEFAULT_PORT ((uint16_t)7769U) // Shared for radar point cloud and radar entities messages
 #define PROVIZIO__RADAR_API_SET_RANGE_DEFAULT_PORT ((uint16_t)7770U)
 #define PROVIZIO__RADAR_API_SET_RANGE_DEFAULT_TIMEOUT ((uint64_t)30000000000ULL)
-#define PROVIZIO__RADAR_API_REQUEST_RANGE_DEFAULT_PORT ((uint16_t)7770U) // Uses "set range to unknown" to request it
+#define PROVIZIO__RADAR_API_REQUEST_RANGE_DEFAULT_PORT                                                                 \
+    PROVIZIO__RADAR_API_SET_RANGE_DEFAULT_PORT // Uses "set range to unknown" to request it
 
 /**
  * @brief A single Provizio Radar API connection handle on a single UDP port
@@ -36,6 +38,8 @@ typedef struct provizio_radar_api_connection
     PROVIZIO__SOCKET sock;
     provizio_radar_point_cloud_api_context *radar_point_cloud_api_contexts;
     size_t num_radar_point_cloud_api_contexts;
+    provizio_radar_entities_api_context *radar_entities_api_contexts;
+    size_t num_radar_entities_api_contexts;
 } provizio_radar_api_connection;
 
 /**
@@ -48,15 +52,17 @@ typedef struct provizio_radar_api_connection
  * returning a successful result
  * @param radar_point_cloud_api_context Initialized provizio_radar_point_cloud_api_context to handle point cloud packets
  * (may be NULL to skip any point cloud packets)
+ * @param radar_entities_api_context Initialized provizio_radar_entities_api_context to handle entities packets (may be
+ * NULL to skip any entities packets)
  * @param out_connection A provizio_radar_api_connection to store the connection handle
  * @return 0 if received successfully, PROVIZIO_E_TIMEOUT if timed out, other error value if failed for another reason
  *
  * @note The connection has to be eventually closed with provizio_close_radar_connection
  */
-PROVIZIO__EXTERN_C int32_t
-provizio_open_radar_connection(uint16_t udp_port, uint64_t receive_timeout_ns, uint8_t check_connection,
-                               provizio_radar_point_cloud_api_context *radar_point_cloud_api_context,
-                               provizio_radar_api_connection *out_connection);
+PROVIZIO__EXTERN_C int32_t provizio_open_radar_connection(
+    uint16_t udp_port, uint64_t receive_timeout_ns, uint8_t check_connection,
+    provizio_radar_point_cloud_api_context *radar_point_cloud_api_context,
+    provizio_radar_entities_api_context *radar_entities_api_context, provizio_radar_api_connection *out_connection);
 
 /**
  * @brief Connect to the radar API to start receiving packets by UDP (multiple radars on the same UDP port)
@@ -70,6 +76,10 @@ provizio_open_radar_connection(uint16_t udp_port, uint64_t receive_timeout_ns, u
  * cloud packets (may be NULL to skip any point cloud packets)
  * @param num_radar_point_cloud_api_contexts Number of radar_point_cloud_api_contexts, i.e. max numbers of radars to
  * handle (may be 0 to skip any point cloud packets)
+ * @param radar_entities_api_contexts Array of initialized provizio_radar_entities_api_context to handle entities
+ * packets (may be NULL to skip any entities packets)
+ * @param num_radar_entities_api_contexts Number of radar_entities_api_contexts, i.e. max numbers of radars to handle
+ * (may be 0 to skip any entities packets)
  * @param out_connection A provizio_radar_api_connection to store the connection handle
  * @return 0 if received successfully, PROVIZIO_E_TIMEOUT if timed out, other error value if failed for another reason
  *
@@ -78,6 +88,7 @@ provizio_open_radar_connection(uint16_t udp_port, uint64_t receive_timeout_ns, u
 PROVIZIO__EXTERN_C int32_t provizio_open_radars_connection(
     uint16_t udp_port, uint64_t receive_timeout_ns, uint8_t check_connection,
     provizio_radar_point_cloud_api_context *radar_point_cloud_api_contexts, size_t num_radar_point_cloud_api_contexts,
+    provizio_radar_entities_api_context *radar_entities_api_contexts, size_t num_radar_entities_api_contexts,
     provizio_radar_api_connection *out_connection);
 
 /**
@@ -108,7 +119,7 @@ PROVIZIO__EXTERN_C int32_t provizio_close_radars_connection(provizio_radar_api_c
  * @param udp_port UDP port to send change range message, by default = PROVIZIO__RADAR_API_SET_RANGE_DEFAULT_PORT
  * (if 0)
  * @param ipv4_address IP address to send change range message, in the standard IPv4 dotted decimal notation. By default
- * = "255.255.255.255" - broadcast (if NULL)
+ * = "255.255.255.255" - broadcast (if NULL). Note: broadcasting to 255.255.255.255 may be unsupported in macOS.
  * @param out_actual_radar_range If not NULL, actual radar range after the operation will be stored here if received
  * from the radar (will be provizio_radar_range_unknown otherwise)
  * @return 0 if set successfully, PROVIZIO_E_TIMEOUT if timed out, other error value if failed for another reason
@@ -127,7 +138,7 @@ PROVIZIO__EXTERN_C int32_t provizio_set_radar_range(provizio_radar_position rada
  * @param udp_port UDP port to send change range message, by default = PROVIZIO__RADAR_API_SET_RANGE_DEFAULT_PORT
  * (if 0)
  * @param ipv4_address IP address to send change range message, in the standard IPv4 dotted decimal notation. By default
- * = "255.255.255.255" - broadcast (if NULL)
+ * = "255.255.255.255" - broadcast (if NULL). Note: broadcasting to 255.255.255.255 may be unsupported in macOS.
  * @param out_actual_radar_range If not NULL, actual radar range after the operation will be stored here if received
  * from the radar (will be provizio_radar_range_unknown otherwise)
  * @param timeout_ns The operation timeout (nanoseconds)
@@ -147,7 +158,7 @@ PROVIZIO__EXTERN_C int32_t provizio_set_radar_range_with_timeout(provizio_radar_
  * @param udp_port UDP port to send the request message, by default = PROVIZIO__RADAR_API_REQUEST_RANGE_DEFAULT_PORT
  * (if 0)
  * @param ipv4_address IP address to send request range message, in the standard IPv4 dotted decimal notation. By
- * default = "255.255.255.255" - broadcast (if NULL)
+ * default = "255.255.255.255" - broadcast (if NULL). Note: broadcasting to 255.255.255.255 may be unsupported in macOS.
  * @param out_current_radar_range Current radar range is stored here if successful (will be provizio_radar_range_unknown
  * otherwise)
  * @return 0 if received successfully, PROVIZIO_E_TIMEOUT if timed out, other error value if failed for another reason

--- a/include/provizio/radar_api/entities.h
+++ b/include/provizio/radar_api/entities.h
@@ -1,0 +1,328 @@
+// Copyright 2025 Provizio Ltd.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PROVIZIO_RADAR_API_ENTITIES
+#define PROVIZIO_RADAR_API_ENTITIES
+
+#include "provizio/quaternion.h"
+#include "provizio/radar_api/common.h"
+#include "provizio/radar_api/radar_position.h"
+#include "provizio/radar_api/radar_ranges.h"
+#include "provizio/socket.h"
+
+// To be incremented on any breaking protocol changes (used for backward compatibility)
+#define PROVIZIO__RADAR_API_ENTITY_PROTOCOL_VERSION ((uint16_t)1)
+
+// Radar entities structures of the binary UDP protocol are defined here, see README.md for more details
+
+typedef enum provizio_entity_class
+{
+    provizio_entity_class_unknown = 0,
+    provizio_entity_class_pedestrian = 1,
+    provizio_entity_class_cyclist = 2,
+    provizio_entity_class_motorbike = 3,
+    provizio_entity_class_car = 4,
+    provizio_entity_class_truck = 5,
+    provizio_entity_class_bus = 6,
+    provizio_entity_class_obstacle = 7
+} provizio_entity_class;
+
+// Use packed structs intended to be sent for binary compatibility across all CPUs
+#pragma pack(push, 1)
+
+typedef struct
+{
+    float x_meters; // Forward, radar relative
+    float y_meters; // Left, radar relative
+    float z_meters; // Up, radar relative
+} provizio_size;
+
+/**
+ * @brief Represents a single entity.
+ *
+ * @warning Given packed structures are used, fields alignment is not guaranteed and caution is needed when accessing
+ * fields on non-x86/x64 systems.
+ * @see provizio_set_protocol_field_float
+ * @see provizio_get_protocol_field_float
+ * @see provizio_get_protocol_field_uint8_t
+ * @see provizio_set_protocol_field_uint8_t
+ * @see provizio_get_protocol_field_uint32_t
+ * @see provizio_set_protocol_field_uint32_t
+ */
+typedef struct
+{
+    uint32_t entity_id;                        // Unique identifier of an entity persistent across frames
+    float x_meters;                            // Forward, radar relative
+    float y_meters;                            // Left, radar relative
+    float z_meters;                            // Up, radar relative
+    float radar_relative_radial_velocity_m_s;  // Forward, radar relative
+    float ground_relative_radial_velocity_m_s; // Ground relative projection to the radar forward axis (NaN if
+                                               // unavailable)
+    provizio_quaternion orientation;           // Orientation quaternion: (w, x, y, z)
+    uint8_t entity_class;                      // One of provizio_entity_class values
+    uint8_t entity_confidence;                 // Confidence the entity actually exists, 0..255
+    uint8_t entity_class_confidence;           // Confidence the entity class is correct, 0..255
+    uint8_t reserved;                          // Unused, reserved for better memory alignment
+} provizio_radar_entity;
+
+/**
+ * @brief Header placed in the beginning of each radar entities packet.
+ *
+ * @note All fields are sent using network bytes order.
+ * @warning Given packed structures are used, fields alignment is not guaranteed and caution is needed when
+ * accessing fields on non-x86/x64 systems.
+ * @see provizio_set_protocol_field_uint16_t
+ * @see provizio_get_protocol_field_uint16_t
+ * @see provizio_set_protocol_field_uint32_t
+ * @see provizio_get_protocol_field_uint32_t
+ * @see provizio_set_protocol_field_uint64_t
+ * @see provizio_get_protocol_field_uint64_t
+ */
+typedef struct provizio_radar_entities_packet_header
+{
+    provizio_radar_api_protocol_header protocol_header;
+
+    uint32_t frame_index; // 0-based
+    uint64_t timestamp; // Time of the latest radar frame capture measured in number of nanoseconds since the Unix Epoch
+    uint16_t radar_position_id;       // Either one of provizio_radar_position enum values or a custom position id
+    uint16_t total_entities_in_frame; // Number of entities in the entire frame
+    uint16_t num_entities_in_packet;  // Number of entities in this single packet
+    uint16_t radar_range;             // One of provizio_radar_range enum values, used
+} provizio_radar_entities_packet_header;
+
+// Max number of radar entities in a single UDP packet
+#define PROVIZIO__MAX_RADAR_ENTITIES_PER_UDP_PACKET                                                                    \
+    ((uint16_t)((PROVIZIO__MAX_PAYLOAD_PER_UDP_PACKET_BYTES - sizeof(provizio_radar_entities_packet_header)) /         \
+                sizeof(provizio_radar_entity)))
+
+// Max number of radar entities in a single frame
+#define PROVIZIO__MAX_RADAR_ENTITIES_PER_FRAME ((uint16_t)0x400)
+
+/**
+ * @brief Structure to hold a single radar entities packet (one of some number of such packets per each frame).
+ *
+ * @note Not all of PROVIZIO__MAX_RADAR_ENTITIES_PER_FRAME entities may be present, see
+ * header.num_entities_in_packet for the actual number stored in this packet.
+ * @warning Given packed structures are used, fields alignment is not guaranteed and caution is needed when
+ * accessing fields on non-x86/x64 systems.
+ */
+PROVIZIO__EXTERN_C typedef struct provizio_radar_entities_packet
+{
+    provizio_radar_entities_packet_header header;
+    provizio_radar_entity radar_entities[PROVIZIO__MAX_RADAR_ENTITIES_PER_UDP_PACKET];
+} provizio_radar_entities_packet;
+
+/**
+ * @brief Returns the total size (in bytes) of the radar entities packet payload, based on its header.
+ *
+ * @param header Header of the packet
+ * @return size_t Size (in bytes)
+ */
+PROVIZIO__EXTERN_C size_t provizio_radar_entities_packet_size(const provizio_radar_entities_packet_header *header);
+
+// Reset alignment settings
+#pragma pack(pop)
+
+/**
+ * @brief A complete or partial radar entities frame
+ *
+ * @note Complete entities frames always have num_entities_received == num_entities_expected
+ */
+typedef struct provizio_radar_entities_frame
+{
+    uint32_t frame_index; // 0-based
+    uint64_t timestamp; // Time of the latest radar frame capture measured in number of nanoseconds since the Unix Epoch
+    uint16_t radar_position_id;     // Either one of provizio_radar_position enum values or a custom position id
+    uint16_t num_entities_expected; // Number of entities in the entire frame
+    uint16_t num_entities_received; // Number of entities in the frame received so far
+    uint16_t radar_range;           // One of provizio_radar_range enum values
+    provizio_radar_entity radar_entities[PROVIZIO__MAX_RADAR_ENTITIES_PER_FRAME];
+} provizio_radar_entities_frame;
+
+struct provizio_radar_entities_api_context;
+typedef void (*provizio_radar_entities_callback)(const provizio_radar_entities_frame *entities_frame,
+                                                 struct provizio_radar_entities_api_context *context);
+
+#ifndef PROVIZIO__RADAR_ENTITIES_API_CONTEXT_IMPL_FRAMES_BEING_RECEIVED_COUNT
+#define PROVIZIO__RADAR_ENTITIES_API_CONTEXT_IMPL_FRAMES_BEING_RECEIVED_COUNT 2
+#endif // PROVIZIO__RADAR_ENTITIES_API_CONTEXT_IMPL_FRAMES_BEING_RECEIVED_COUNT
+typedef struct provizio_radar_entities_api_context_impl
+{
+    uint32_t latest_frame;
+    provizio_radar_entities_frame
+        entities_frames_being_received[PROVIZIO__RADAR_ENTITIES_API_CONTEXT_IMPL_FRAMES_BEING_RECEIVED_COUNT];
+} provizio_radar_entities_api_context_impl;
+
+/**
+ * @brief Keeps all data required for functioning of entities API
+ */
+typedef struct provizio_radar_entities_api_context
+{
+    provizio_radar_entities_callback callback;
+    void *user_data;
+    uint16_t radar_position_id;
+
+    provizio_radar_entities_api_context_impl impl;
+} provizio_radar_entities_api_context;
+
+/**
+ * @brief Initializes a provizio_radar_entities_api_context object to handle a single radar
+ *
+ * @param callback Function to be called on receiving a complete or partial entities frame
+ * @param user_data Custom argument to be passed to the callback, may be NULL
+ * @param context The provizio_radar_entities_api_context object to initialize
+ *
+ * @note radar_position_id of all packets handled by this context must be same
+ */
+PROVIZIO__EXTERN_C void provizio_radar_entities_api_context_init(provizio_radar_entities_callback callback,
+                                                                 void *user_data,
+                                                                 provizio_radar_entities_api_context *context);
+
+/**
+ * @brief Initializes multiple provizio_radar_entities_api_context objects to handle packets from multiple radars
+ *
+ * @param callback Function to be called on receiving a complete or partial entities frame
+ * @param user_data Custom argument to be passed to the callback, may be NULL
+ * @param contexts Array of num_contexts of provizio_radar_entities_api_context objects to initialize
+ * @param num_contexts Number of contexts (i.e. max numbers of radars to handle) to initialize
+ */
+PROVIZIO__EXTERN_C void provizio_radar_entities_api_contexts_init(provizio_radar_entities_callback callback,
+                                                                  void *user_data,
+                                                                  provizio_radar_entities_api_context *contexts,
+                                                                  size_t num_contexts);
+
+/**
+ * @brief Makes provizio_radar_entities_callback object handle a specific radar, which makes it skip packets
+ * intended for other radars
+ *
+ * @param context provizio_radar_entities_api_context to be assigned
+ * @param radar_position_id radar to assign
+ * @return 0 in case it was successfully assigned, an error code otherwise
+ */
+PROVIZIO__EXTERN_C int32_t provizio_radar_entities_api_context_assign(provizio_radar_entities_api_context *context,
+                                                                      provizio_radar_position radar_position_id);
+
+/**
+ * @brief Handles a single radar entities UDP packet from a single radar
+ *
+ * @param context Previously initialized provizio_radar_entities_api_context
+ * @param packet Valid provizio_radar_entities_packet
+ * @param packet_size The size of the packet, to check data is valid and avoid out-of-bounds access
+ * @return 0 in case the packet was handled successfully, PROVIZIO_E_SKIPPED in case the packet was skipped as obsolete,
+ * other error code in case of another error
+ *
+ * @note radar_position_id of all packets handled by this context must be same (returns an error otherwise)
+ */
+PROVIZIO__EXTERN_C int32_t provizio_handle_entities_packet(provizio_radar_entities_api_context *context,
+                                                           provizio_radar_entities_packet *packet, size_t packet_size);
+
+/**
+ * @brief Handles a single radar entities UDP packet from one of multiple radars
+ *
+ * @param contexts Previously initialized array of num_contexts of provizio_radar_entities_api_context objects
+ * @param num_contexts Number of contexts (i.e. max numbers of radars to handle)
+ * @param packet Valid provizio_radar_entities_packet
+ * @param packet_size The size of the packet, to check data is valid and avoid out-of-bounds access
+ * @return 0 in case the packet was handled successfully, PROVIZIO_E_SKIPPED in case the packet was skipped as obsolete,
+ * PROVIZIO_E_OUT_OF_CONTEXTS in case num_contexts is not enough, other error code in case of another error
+ */
+PROVIZIO__EXTERN_C int32_t provizio_handle_radars_entities_packet(provizio_radar_entities_api_context *contexts,
+                                                                  size_t num_contexts,
+                                                                  provizio_radar_entities_packet *packet,
+                                                                  size_t packet_size);
+
+/**
+ * @brief Handles a single Provizio Radar API UDP packet from a single radar, that can be a correct
+ * provizio_radar_entities_packet or something else
+ *
+ * @param context Previously initialized provizio_radar_entities_api_context
+ * @param payload The payload of the UDP packet
+ * @param payload_size The size of the payload in bytes
+ * @return 0 if it's a provizio_radar_entities_packet and it was handled successfully, PROVIZIO_E_SKIPPED if it's not
+ * a provizio_radar_entities_packet, other error code if it's a provizio_radar_entities_packet but its handling
+ * failed for another reason
+ *
+ * @note if it's a provizio_radar_entities_packet, radar_position_id of all packets handled by this context must
+ * be same (returns an error otherwise)
+ */
+PROVIZIO__EXTERN_C int32_t provizio_handle_possible_radar_entities_packet(provizio_radar_entities_api_context *context,
+                                                                          const void *payload, size_t payload_size);
+
+/**
+ * @brief Handles a single Provizio Radar API UDP packet from one of multiple radars, that can be a correct
+ * provizio_radar_entities_packet or something else
+ *
+ * @param contexts Previously initialized array of num_contexts of provizio_radar_entities_api_context objects
+ * @param num_contexts Number of contexts (i.e. max numbers of radars to handle)
+ * @param payload The payload of the UDP packet
+ * @param payload_size The size of the payload in bytes
+ * @return 0 if it's a provizio_radar_entities_packet and it was handled successfully, PROVIZIO_E_SKIPPED if it's not
+ * a provizio_radar_entities_packet, PROVIZIO_E_OUT_OF_CONTEXTS in case num_contexts is not enough, other error code
+ * if it's a provizio_radar_entities_packet but its handling failed for another reason
+ */
+PROVIZIO__EXTERN_C int32_t provizio_handle_possible_radars_entities_packet(
+    provizio_radar_entities_api_context *contexts, size_t num_contexts, const void *payload, size_t payload_size);
+
+#if defined(__cplusplus) && __cplusplus >= 201103L
+static_assert(offsetof(provizio_radar_entities_packet_header, protocol_header) == 0,
+              "Unexpected position of protocol_header in provizio_radar_entities_packet_header");
+static_assert(offsetof(provizio_radar_entities_packet_header, frame_index) == 4,
+              "Unexpected position of frame_index in provizio_radar_entities_packet_header");
+static_assert(offsetof(provizio_radar_entities_packet_header, timestamp) == 8,
+              "Unexpected position of timestamp in provizio_radar_entities_packet_header");
+static_assert(offsetof(provizio_radar_entities_packet_header, radar_position_id) == 16,
+              "Unexpected position of radar_position_id in provizio_radar_entities_packet_header");
+static_assert(offsetof(provizio_radar_entities_packet_header, total_entities_in_frame) == 18,
+              "Unexpected position of total_entities_in_frame in provizio_radar_entities_packet_header");
+static_assert(offsetof(provizio_radar_entities_packet_header, num_entities_in_packet) == 20,
+              "Unexpected position of num_entities_in_packet in provizio_radar_entities_packet_header");
+static_assert(sizeof(provizio_radar_entities_packet_header) == 24,
+              "Unexpected size of provizio_radar_entities_packet_header");
+static_assert(offsetof(provizio_radar_entities_packet, header) == 0,
+              "Unexpected position of header in provizio_radar_entities_packet");
+static_assert(offsetof(provizio_radar_entities_packet, radar_entities) == sizeof(provizio_radar_entities_packet_header),
+              "Unexpected position of radar_entities in provizio_radar_entities_packet");
+static_assert(sizeof(provizio_radar_entities_packet) ==
+                  sizeof(provizio_radar_entities_packet_header) +
+                      sizeof(provizio_radar_entity) * PROVIZIO__MAX_RADAR_ENTITIES_PER_UDP_PACKET,
+              "Unexpected size of provizio_radar_entities_packet");
+static_assert(offsetof(provizio_radar_entity, entity_id) == 0,
+              "Unexpected position of entity_id in provizio_radar_entity");
+static_assert(offsetof(provizio_radar_entity, x_meters) == 4,
+              "Unexpected position of x_meters in provizio_radar_entity");
+static_assert(offsetof(provizio_radar_entity, y_meters) == 8,
+              "Unexpected position of y_meters in provizio_radar_entity");
+static_assert(offsetof(provizio_radar_entity, z_meters) == 12,
+              "Unexpected position of z_meters in provizio_radar_entity");
+static_assert(offsetof(provizio_radar_entity, radar_relative_radial_velocity_m_s) == 16,
+              "Unexpected position of radar_relative_radial_velocity_m_s in provizio_radar_entity");
+static_assert(offsetof(provizio_radar_entity, ground_relative_radial_velocity_m_s) == 20,
+              "Unexpected position of ground_relative_radial_velocity_m_s in provizio_radar_entity");
+static_assert(offsetof(provizio_radar_entity, orientation) == 24,
+              "Unexpected position of orientation in provizio_radar_entity");
+static_assert(offsetof(provizio_radar_entity, entity_class) == 40,
+              "Unexpected position of entity_class in provizio_radar_entity");
+static_assert(offsetof(provizio_radar_entity, entity_confidence) == 41,
+              "Unexpected position of entity_confidence in provizio_radar_entity");
+static_assert(offsetof(provizio_radar_entity, entity_class_confidence) == 42,
+              "Unexpected position of entity_class_confidence in provizio_radar_entity");
+static_assert(offsetof(provizio_radar_entity, reserved) == 43,
+              "Unexpected position of reserved in provizio_radar_entity");
+static_assert(sizeof(provizio_radar_entity) == 44, "Unexpected size of provizio_radar_entity");
+static_assert(offsetof(provizio_size, x_meters) == 0, "Unexpected position of x_meters in provizio_size");
+static_assert(offsetof(provizio_size, y_meters) == 4, "Unexpected position of y_meters in provizio_size");
+static_assert(offsetof(provizio_size, z_meters) == 8, "Unexpected position of z_meters in provizio_size");
+static_assert(sizeof(provizio_size) == 12, "Unexpected size of provizio_size");
+#endif // defined(__cplusplus) && __cplusplus >= 201103L
+
+#endif // PROVIZIO_RADAR_API_ENTITIES

--- a/include/provizio/radar_api/entities.h
+++ b/include/provizio/radar_api/entities.h
@@ -69,6 +69,7 @@ typedef struct
     float ground_relative_radial_velocity_m_s; // Ground relative projection to the radar forward axis (NaN if
                                                // unavailable)
     provizio_quaternion orientation;           // Orientation quaternion: (w, x, y, z)
+    provizio_size size;                        // Bounding box size (x, y, z)
     uint8_t entity_class;                      // One of provizio_entity_class values
     uint8_t entity_confidence;                 // Confidence the entity actually exists, 0..255
     uint8_t entity_class_confidence;           // Confidence the entity class is correct, 0..255
@@ -310,15 +311,14 @@ static_assert(offsetof(provizio_radar_entity, ground_relative_radial_velocity_m_
               "Unexpected position of ground_relative_radial_velocity_m_s in provizio_radar_entity");
 static_assert(offsetof(provizio_radar_entity, orientation) == 24,
               "Unexpected position of orientation in provizio_radar_entity");
-static_assert(offsetof(provizio_radar_entity, entity_class) == 40,
+static_assert(offsetof(provizio_radar_entity, size) == 40, "Unexpected position of size in provizio_radar_entity");
+static_assert(offsetof(provizio_radar_entity, entity_class) == 52,
               "Unexpected position of entity_class in provizio_radar_entity");
-static_assert(offsetof(provizio_radar_entity, entity_confidence) == 41,
+static_assert(offsetof(provizio_radar_entity, entity_confidence) == 53,
               "Unexpected position of entity_confidence in provizio_radar_entity");
-static_assert(offsetof(provizio_radar_entity, entity_class_confidence) == 42,
+static_assert(offsetof(provizio_radar_entity, entity_class_confidence) == 54,
               "Unexpected position of entity_class_confidence in provizio_radar_entity");
-static_assert(offsetof(provizio_radar_entity, reserved) == 43,
-              "Unexpected position of reserved in provizio_radar_entity");
-static_assert(sizeof(provizio_radar_entity) == 44, "Unexpected size of provizio_radar_entity");
+static_assert(sizeof(provizio_radar_entity) == 56, "Unexpected size of provizio_radar_entity");
 static_assert(offsetof(provizio_size, x_meters) == 0, "Unexpected position of x_meters in provizio_size");
 static_assert(offsetof(provizio_size, y_meters) == 4, "Unexpected position of y_meters in provizio_size");
 static_assert(offsetof(provizio_size, z_meters) == 8, "Unexpected position of z_meters in provizio_size");

--- a/include/provizio/radar_api/radar_point_cloud.h
+++ b/include/provizio/radar_api/radar_point_cloud.h
@@ -64,9 +64,8 @@ typedef struct provizio_radar_point_cloud_packet_header
 {
     provizio_radar_api_protocol_header protocol_header;
 
-    uint32_t frame_index; // 0-based
-    uint64_t timestamp;   // Time of the frame capture measured in absolute number of nanoseconds since the start of the
-                          // GPS Epoch (midnight on Jan 6, 1980)
+    uint32_t frame_index;           // 0-based
+    uint64_t timestamp;             // Time of the frame capture measured in number of nanoseconds since the Unix Epoch
     uint16_t radar_position_id;     // Either one of provizio_radar_position enum values or a custom position id
     uint16_t total_points_in_frame; // Number of points in the entire frame
     uint16_t num_points_in_packet;  // Number of points in this single packet
@@ -116,9 +115,8 @@ provizio_radar_point_cloud_packet_size(const provizio_radar_point_cloud_packet_h
  */
 typedef struct provizio_radar_point_cloud
 {
-    uint32_t frame_index; // 0-based
-    uint64_t timestamp;   // Time of the frame capture measured in absolute number of nanoseconds since the start of the
-                          // GPS Epoch (midnight on Jan 6, 1980)
+    uint32_t frame_index;         // 0-based
+    uint64_t timestamp;           // Time of the frame capture measured in number of nanoseconds since the Unix Epoch
     uint16_t radar_position_id;   // Either one of provizio_radar_position enum values or a custom position id
     uint16_t num_points_expected; // Number of points in the entire frame
     uint16_t num_points_received; // Number of points in the frame received so far
@@ -159,7 +157,7 @@ typedef struct provizio_radar_point_cloud_api_context
  * @param user_data Custom argument to be passed to the callback, may be NULL
  * @param context The provizio_radar_point_cloud_api_context object to initialize
  *
- * @warning radar_position_id of all packets handled by this context must be same
+ * @note radar_position_id of all packets handled by this context must be same
  */
 PROVIZIO__EXTERN_C void provizio_radar_point_cloud_api_context_init(provizio_radar_point_cloud_callback callback,
                                                                     void *user_data,
@@ -198,7 +196,7 @@ PROVIZIO__EXTERN_C int32_t provizio_radar_point_cloud_api_context_assign(
  * @return 0 in case the packet was handled successfully, PROVIZIO_E_SKIPPED in case the packet was skipped as obsolete,
  * other error code in case of another error
  *
- * @warning radar_position_id of all packets handled by this context must be same (returns an error otherwise)
+ * @note radar_position_id of all packets handled by this context must be same (returns an error otherwise)
  */
 PROVIZIO__EXTERN_C int32_t provizio_handle_radar_point_cloud_packet(provizio_radar_point_cloud_api_context *context,
                                                                     provizio_radar_point_cloud_packet *packet,
@@ -230,7 +228,7 @@ PROVIZIO__EXTERN_C int32_t provizio_handle_radars_point_cloud_packet(provizio_ra
  * a provizio_radar_point_cloud_packet, other error code if it's a provizio_radar_point_cloud_packet but its handling
  * failed for another reason
  *
- * @warning if it's a provizio_radar_point_cloud_packet, radar_position_id of all packets handled by this context must
+ * @note if it's a provizio_radar_point_cloud_packet, radar_position_id of all packets handled by this context must
  * be same (returns an error otherwise)
  */
 PROVIZIO__EXTERN_C int32_t provizio_handle_possible_radar_point_cloud_packet(

--- a/include/provizio/radar_api/radar_points_accumulation_types.h
+++ b/include/provizio/radar_api/radar_points_accumulation_types.h
@@ -16,23 +16,8 @@
 #define PROVIZIO_RADAR_API_RADAR_POINTS_ACCUMULATION_TYPES
 
 #include "provizio/common.h"
+#include "provizio/quaternion.h"
 #include "provizio/radar_api/radar_point_cloud.h"
-
-/**
- * @brief Represents a quaternion, normally a unit quaternion storing a spatial orientation.
- *
- * @see https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation
- * @see provizio_quaternion_set_identity
- * @see provizio_quaternion_set_euler_angles
- * @see provizio_quaternion_is_valid_rotation
- */
-typedef struct provizio_quaternion
-{
-    float w;
-    float x;
-    float y;
-    float z;
-} provizio_quaternion;
 
 /**
  * @brief Represents a position as right-handed cartesian coordinates (East, North, Up) in meters, relative to whatever
@@ -95,38 +80,6 @@ typedef struct provizio_accumulated_radar_point_cloud_iterator
     size_t point_cloud_index;
     size_t point_index;
 } provizio_accumulated_radar_point_cloud_iterator;
-
-/**
- * @brief Sets the specified quaternion to identity, i.e. east-looking orientation.
- *
- * @param out_quaternion The quaternion to be set.
- * @see provizio_quaternion
- */
-PROVIZIO__EXTERN_C void provizio_quaternion_set_identity(provizio_quaternion *out_quaternion);
-
-/**
- * @brief Sets the specified quaternion from the specified Euler angles, as applied in this order: z, y, x (yaw, pitch,
- * roll).
- *
- * @param x_rad Rotation around the forward (roll) or east axis, depending on the context (radians).
- * @param y_rad Rotation around the left (pitch) or north axis, depending on the context (radians).
- * @param z_rad Rotation around the up (yaw) axis (radians).
- * @param out_quaternion The rotation/orientation quaternion to be set.
- * @see https://en.wikipedia.org/wiki/Euler_angles
- * @see provizio_quaternion
- * @see provizio_quaternion_set_identity
- */
-PROVIZIO__EXTERN_C void provizio_quaternion_set_euler_angles(float x_rad, float y_rad, float z_rad,
-                                                             provizio_quaternion *out_quaternion);
-
-/**
- * @brief Checks if the specified quaternion is a valid rotation/orientation quaternion.
- *
- * @param quaternion The quaternion to be checked.
- * @return Non-zero if valid, zero otherwise.
- * @see provizio_quaternion
- */
-PROVIZIO__EXTERN_C uint8_t provizio_quaternion_is_valid_rotation(const provizio_quaternion *quaternion);
 
 /**
  * @brief Measures distance (in meters) between two ENU positions

--- a/src/core.c
+++ b/src/core.c
@@ -15,20 +15,25 @@
 #include "provizio/radar_api/core.h"
 #include "provizio/util.h"
 
+#include <stdio.h>
 #include <string.h>
 
 int32_t provizio_open_radar_connection(uint16_t udp_port, uint64_t receive_timeout_ns, uint8_t check_connection,
                                        provizio_radar_point_cloud_api_context *radar_point_cloud_api_context,
+                                       provizio_radar_entities_api_context *radar_entities_api_context,
                                        provizio_radar_api_connection *out_connection)
 {
     return provizio_open_radars_connection(udp_port, receive_timeout_ns, check_connection,
                                            radar_point_cloud_api_context, radar_point_cloud_api_context != NULL ? 1 : 0,
+                                           radar_entities_api_context, radar_entities_api_context != NULL ? 1 : 0,
                                            out_connection);
 }
 
 int32_t provizio_open_radars_connection(uint16_t udp_port, uint64_t receive_timeout_ns, uint8_t check_connection,
                                         provizio_radar_point_cloud_api_context *radar_point_cloud_api_contexts,
                                         size_t num_radar_point_cloud_api_contexts,
+                                        provizio_radar_entities_api_context *radar_entities_api_contexts,
+                                        size_t num_radar_entities_api_contexts,
                                         provizio_radar_api_connection *out_connection)
 {
     memset(out_connection, 0, sizeof(provizio_radar_api_connection));
@@ -128,6 +133,8 @@ int32_t provizio_open_radars_connection(uint16_t udp_port, uint64_t receive_time
     out_connection->sock = sock;
     out_connection->radar_point_cloud_api_contexts = radar_point_cloud_api_contexts;
     out_connection->num_radar_point_cloud_api_contexts = num_radar_point_cloud_api_contexts;
+    out_connection->radar_entities_api_contexts = radar_entities_api_contexts;
+    out_connection->num_radar_entities_api_contexts = num_radar_entities_api_contexts;
 
     provizio_verbose("provizio_open_radars_connection: Connected");
 
@@ -165,13 +172,21 @@ int32_t provizio_radar_api_receive_packet(provizio_radar_api_connection *connect
 
     int32_t status_code = PROVIZIO_E_SKIPPED;
 
-    // Let's try to handle it as a point cloud packet
+    // Try handling it as a point cloud packet
     if (status_code == PROVIZIO_E_SKIPPED && connection->num_radar_point_cloud_api_contexts > 0 &&
         connection->radar_point_cloud_api_contexts != NULL)
     {
         status_code = provizio_handle_possible_radars_point_cloud_packet(connection->radar_point_cloud_api_contexts,
                                                                          connection->num_radar_point_cloud_api_contexts,
                                                                          packet, received);
+    }
+
+    // Try handling it as an entities packet
+    if (status_code == PROVIZIO_E_SKIPPED && connection->num_radar_entities_api_contexts > 0 &&
+        connection->radar_entities_api_contexts != NULL)
+    {
+        status_code = provizio_handle_possible_radars_entities_packet(
+            connection->radar_entities_api_contexts, connection->num_radar_entities_api_contexts, packet, received);
     }
 
     return status_code;
@@ -226,7 +241,7 @@ int32_t provizio_set_radar_range_with_timeout(provizio_radar_position radar_posi
         *out_actual_radar_range = provizio_radar_range_unknown;
     }
 
-    if (timeout_ns / recv_timeout_ns + max_ack_recv_tries > INT32_MAX)
+    if ((timeout_ns / recv_timeout_ns) + max_ack_recv_tries > INT32_MAX)
     {
         provizio_error("provizio_set_radar_range_with_timeout: timeout_ns is too large");
         return PROVIZIO_E_ARGUMENT;
@@ -268,6 +283,22 @@ int32_t provizio_set_radar_range_with_timeout(provizio_radar_position radar_posi
             return status;
             // LCOV_EXCL_STOP
         }
+#if defined(IPPROTO_IP) && defined(IP_ONESBCAST)
+        if (ipv4_address == NULL || strcmp(ipv4_address, broadcast_ipv4_address) == 0)
+        {
+            const int ones_broadcast = 1;
+            status = (int32_t)setsockopt(sock, IPPROTO_IP, IP_ONESBCAST, (const char *)&ones_broadcast,
+                                         sizeof(ones_broadcast));
+            if (status != 0)
+            {
+                // LCOV_EXCL_START: Can't be unit-tested as it depends on the state of the OS
+                provizio_error("provizio_set_radar_range_with_timeout: Failed to enable limited broadcasting support!");
+                provizio_socket_close(sock);
+                return status;
+                // LCOV_EXCL_STOP
+            }
+        }
+#endif
     }
 
     struct sockaddr_in my_address;
@@ -318,9 +349,30 @@ int32_t provizio_set_radar_range_with_timeout(provizio_radar_position radar_posi
         if (status < 0)
         {
             // LCOV_EXCL_START: Can't be unit-tested as it depends on the state of the OS
-            provizio_error("provizio_set_radar_range_with_timeout: Failed to send provizio_set_radar_range_packet");
+#define PROVIZIO__ERROR_MESSAGE_BUFFER_SIZE (1024)
+#define PROVIZIO__ERROR_STRING_BUFFER_SIZE (64)
+            const int32_t send_error = (int32_t)errno;
+            char strerror_buffer[PROVIZIO__ERROR_STRING_BUFFER_SIZE];
+#ifdef _WIN32
+            (void)strerror_s(strerror_buffer, sizeof(strerror_buffer), send_error);
+            const char *send_error_string = strerror_buffer;
+#else
+            if (strerror_r(send_error, strerror_buffer, sizeof(strerror_buffer)) != 0)
+            {
+                strerror_buffer[0] = '\0';
+            }
+            const char *send_error_string = strerror_buffer;
+#endif
+            char error_message_buffer[PROVIZIO__ERROR_MESSAGE_BUFFER_SIZE];
+            (void)snprintf(error_message_buffer, PROVIZIO__ERROR_MESSAGE_BUFFER_SIZE,
+                           "provizio_set_radar_range_with_timeout: Failed to send provizio_set_radar_range_packet - "
+                           "errno %d (%s)",
+                           (int)send_error, send_error_string[0] != '\0' ? send_error_string : "unknown");
+            provizio_error(error_message_buffer);
             provizio_socket_close(sock);
-            return status;
+            return send_error != 0 ? send_error : (int32_t)-1;
+#undef PROVIZIO__ERROR_STRING_BUFFER_SIZE
+#undef PROVIZIO__ERROR_MESSAGE_BUFFER_SIZE
             // LCOV_EXCL_STOP
         }
 

--- a/src/core.c
+++ b/src/core.c
@@ -350,28 +350,15 @@ int32_t provizio_set_radar_range_with_timeout(provizio_radar_position radar_posi
         {
             // LCOV_EXCL_START: Can't be unit-tested as it depends on the state of the OS
 #define PROVIZIO__ERROR_MESSAGE_BUFFER_SIZE (1024)
-#define PROVIZIO__ERROR_STRING_BUFFER_SIZE (64)
             const int32_t send_error = (int32_t)errno;
-            char strerror_buffer[PROVIZIO__ERROR_STRING_BUFFER_SIZE];
-#ifdef _WIN32
-            (void)strerror_s(strerror_buffer, sizeof(strerror_buffer), send_error);
-            const char *send_error_string = strerror_buffer;
-#else
-            if (strerror_r(send_error, strerror_buffer, sizeof(strerror_buffer)) != 0)
-            {
-                strerror_buffer[0] = '\0';
-            }
-            const char *send_error_string = strerror_buffer;
-#endif
             char error_message_buffer[PROVIZIO__ERROR_MESSAGE_BUFFER_SIZE];
             (void)snprintf(error_message_buffer, PROVIZIO__ERROR_MESSAGE_BUFFER_SIZE,
                            "provizio_set_radar_range_with_timeout: Failed to send provizio_set_radar_range_packet - "
-                           "errno %d (%s)",
-                           (int)send_error, send_error_string[0] != '\0' ? send_error_string : "unknown");
+                           "errno %d",
+                           (int)send_error);
             provizio_error(error_message_buffer);
             provizio_socket_close(sock);
             return send_error != 0 ? send_error : (int32_t)-1;
-#undef PROVIZIO__ERROR_STRING_BUFFER_SIZE
 #undef PROVIZIO__ERROR_MESSAGE_BUFFER_SIZE
             // LCOV_EXCL_STOP
         }

--- a/src/entities.c
+++ b/src/entities.c
@@ -277,7 +277,11 @@ int32_t provizio_check_for_too_many_entities(provizio_radar_entities_frame *fram
     if ((uint32_t)frame->num_entities_received + (uint32_t)num_entities_in_packet >
         (uint32_t)frame->num_entities_expected)
     {
-        provizio_error("provizio_check_for_too_many_entities: Too many entities received");
+        provizio_error("provizio_check_for_too_many_entities: Too many entities received"
+#ifndef PROVIZIO__AVOID_PACKETS_DUPLICATION
+                       ", consider enabling AVOID_PACKETS_DUPLICATION option"
+#endif
+        );
         return PROVIZIO_E_PROTOCOL;
     }
 
@@ -303,13 +307,20 @@ int32_t provizio_handle_entities_packet_checked(provizio_radar_entities_api_cont
     const uint16_t num_entities_in_packet =
         provizio_get_protocol_field_uint16_t(&packet->header.num_entities_in_packet);
 
-    const int32_t status = provizio_check_for_too_many_entities(frame, num_entities_in_packet);
-    if (status != 0)
+#ifndef PROVIZIO__AVOID_PACKETS_DUPLICATION
     {
-        return status;
+        const int32_t status = provizio_check_for_too_many_entities(frame, num_entities_in_packet);
+        if (status != 0)
+        {
+            return status;
+        }
     }
-
     provizio_radar_entity *output_to = &frame->radar_entities[frame->num_entities_received];
+#else
+    provizio_radar_entity output_buffer[PROVIZIO__MAX_RADAR_ENTITIES_PER_UDP_PACKET];
+    memset(output_buffer, 0, sizeof(output_buffer));
+    provizio_radar_entity *output_to = output_buffer;
+#endif
 
     for (uint16_t i = 0; i < num_entities_in_packet; ++i)
     {
@@ -328,11 +339,55 @@ int32_t provizio_handle_entities_packet_checked(provizio_radar_entities_api_cont
         out_entity->orientation.x = provizio_get_protocol_field_float(&in_entity->orientation.x);
         out_entity->orientation.y = provizio_get_protocol_field_float(&in_entity->orientation.y);
         out_entity->orientation.z = provizio_get_protocol_field_float(&in_entity->orientation.z);
+        out_entity->size.x_meters = provizio_get_protocol_field_float(&in_entity->size.x_meters);
+        out_entity->size.y_meters = provizio_get_protocol_field_float(&in_entity->size.y_meters);
+        out_entity->size.z_meters = provizio_get_protocol_field_float(&in_entity->size.z_meters);
         out_entity->entity_class = provizio_get_protocol_field_uint8_t(&in_entity->entity_class);
         out_entity->entity_confidence = provizio_get_protocol_field_uint8_t(&in_entity->entity_confidence);
         out_entity->entity_class_confidence = provizio_get_protocol_field_uint8_t(&in_entity->entity_class_confidence);
         out_entity->reserved = provizio_get_protocol_field_uint8_t(&in_entity->reserved);
     }
+
+#ifdef PROVIZIO__AVOID_PACKETS_DUPLICATION
+    for (uint16_t past_packet_start = 0; past_packet_start + num_entities_in_packet <= frame->num_entities_received;
+         ++past_packet_start)
+    {
+        provizio_radar_entity *packet_in_cloud = &frame->radar_entities[past_packet_start];
+        if (memcmp(packet_in_cloud, output_buffer, sizeof(provizio_radar_entity) * num_entities_in_packet) == 0)
+        {
+            // Drop the duplication
+            provizio_verbose("provizio_handle_entities_packet_checked: Packet dropped as duplicated");
+            return PROVIZIO_E_SKIPPED;
+        }
+    }
+
+    {
+        int32_t status = provizio_check_for_too_many_entities(frame, num_entities_in_packet);
+        if (status != 0)
+        {
+            return status;
+        }
+    }
+
+    memcpy(&frame->radar_entities[frame->num_entities_received], output_to,
+           sizeof(provizio_radar_entity) * num_entities_in_packet);
+#endif
+
+#ifdef PROVIZIO__VERBOSE
+    for (uint16_t i = 0; i < num_entities_in_packet; ++i)
+    {
+        provizio_radar_entity *out_entity = output_to + i;
+        provizio_verbose("provizio_handle_entities_packet_checked: Got entity at frame #%d: {%d, %f, %f, %f, %f, %f, "
+                         "{%f, %f, %f, %f}, {%f, %f, %f}, %d, %d, %d}",
+                         (int)frame->frame_index, (int)out_entity->entity_id, out_entity->x_meters,
+                         out_entity->y_meters, out_entity->z_meters, out_entity->radar_relative_radial_velocity_m_s,
+                         out_entity->ground_relative_radial_velocity_m_s, out_entity->orientation.w,
+                         out_entity->orientation.x, out_entity->orientation.y, out_entity->orientation.z,
+                         out_entity->size.x_meters, out_entity->size.y_meters, out_entity->size.z_meters,
+                         (int)out_entity->entity_class, (int)out_entity->entity_confidence,
+                         (int)out_entity->entity_class_confidence);
+    }
+#endif // PROVIZIO__VERBOSE
 
     frame->num_entities_received += num_entities_in_packet;
 

--- a/src/entities.c
+++ b/src/entities.c
@@ -1,0 +1,448 @@
+// Copyright 2025 Provizio Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "provizio/radar_api/entities.h"
+
+#include <assert.h>
+#include <string.h>
+
+#include "provizio/radar_api/errno.h"
+#include "provizio/util.h"
+
+void provizio_return_entities_frame(provizio_radar_entities_api_context *context, provizio_radar_entities_frame *frame)
+{
+    // Make sure all older but incomplete frames are returned first
+#pragma unroll
+    for (size_t i = 0; i < PROVIZIO__RADAR_ENTITIES_API_CONTEXT_IMPL_FRAMES_BEING_RECEIVED_COUNT; ++i)
+    {
+        provizio_radar_entities_frame *other_frame = &context->impl.entities_frames_being_received[i];
+        if (other_frame != frame && other_frame->num_entities_expected > 0 &&
+            other_frame->frame_index < frame->frame_index)
+        {
+            provizio_return_entities_frame(context, other_frame);
+        }
+    }
+
+    context->callback(frame, context);
+    memset(frame, 0, sizeof(provizio_radar_entities_frame));
+}
+
+provizio_radar_entities_frame *provizio_get_entities_frame_being_received(
+    provizio_radar_entities_api_context *context, provizio_radar_entities_packet_header *packet_header)
+{
+    const uint32_t small_frame_index_cap = 0x0000ffff;
+    const uint32_t large_frame_index_threshold = 0xffff0000;
+
+    provizio_radar_entities_frame *frame = NULL;
+
+    const uint16_t radar_position_id = provizio_get_protocol_field_uint16_t(&packet_header->radar_position_id);
+    const uint32_t frame_index = provizio_get_protocol_field_uint32_t(&packet_header->frame_index);
+    const uint16_t total_entities_in_frame =
+        provizio_get_protocol_field_uint16_t(&packet_header->total_entities_in_frame);
+    const uint16_t radar_range = provizio_get_protocol_field_uint16_t(&packet_header->radar_range);
+
+    if (frame_index < small_frame_index_cap && context->impl.latest_frame > large_frame_index_threshold)
+    {
+        provizio_warning("provizio_get_entities_frame_being_received: frame indices overflow detected - resetting API "
+                         "state");
+        provizio_radar_entities_api_context_init(context->callback, context->user_data, context);
+    }
+
+    if (context->radar_position_id == provizio_radar_position_unknown)
+    {
+        provizio_radar_entities_api_context_assign(context, radar_position_id);
+    }
+    else if (context->radar_position_id != radar_position_id)
+    {
+        return NULL;
+    }
+
+    if (context->impl.latest_frame < frame_index)
+    {
+        context->impl.latest_frame = frame_index;
+    }
+
+    // Look for a frame already being received
+#pragma unroll
+    for (size_t i = 0; i < PROVIZIO__RADAR_ENTITIES_API_CONTEXT_IMPL_FRAMES_BEING_RECEIVED_COUNT; ++i)
+    {
+        frame = &context->impl.entities_frames_being_received[i];
+        if (frame->frame_index == frame_index && frame->num_entities_expected > 0)
+        {
+            if (frame->num_entities_expected != total_entities_in_frame)
+            {
+                provizio_warning("provizio_get_entities_frame_being_received: num_entities_expected mismatch across "
+                                 "different packets of the same frame");
+            }
+
+            if (frame->radar_range != radar_range)
+            {
+                provizio_warning("provizio_get_entities_frame_being_received: radar_range mismatch across different "
+                                 "packets of the same frame");
+            }
+
+            return frame;
+        }
+    }
+
+    provizio_radar_entities_frame *result = NULL;
+
+    // Look for an empty frame slot
+#pragma unroll
+    for (size_t i = 0; i < PROVIZIO__RADAR_ENTITIES_API_CONTEXT_IMPL_FRAMES_BEING_RECEIVED_COUNT; ++i)
+    {
+        frame = &context->impl.entities_frames_being_received[i];
+        if (frame->num_entities_expected == 0)
+        {
+            result = frame;
+        }
+    }
+
+    if (!result)
+    {
+        // Drop (return incomplete) the oldest incomplete frame unless it's newer than the incoming packet
+#pragma unroll
+        for (size_t i = 0; i < PROVIZIO__RADAR_ENTITIES_API_CONTEXT_IMPL_FRAMES_BEING_RECEIVED_COUNT; ++i)
+        {
+            frame = &context->impl.entities_frames_being_received[i];
+            if (frame->frame_index < frame_index && (!result || frame->frame_index < result->frame_index))
+            {
+                result = frame;
+            }
+        }
+
+        if (result != NULL)
+        {
+            provizio_return_entities_frame(context, result);
+        }
+    }
+
+    if (result != NULL)
+    {
+        result->frame_index = frame_index;
+        result->timestamp = provizio_get_protocol_field_uint64_t(&packet_header->timestamp);
+        result->radar_position_id = radar_position_id;
+        result->num_entities_expected = total_entities_in_frame;
+        result->radar_range = radar_range;
+        assert(result->num_entities_received == 0);
+    }
+
+    return result;
+}
+
+size_t provizio_radar_entities_packet_size(const provizio_radar_entities_packet_header *header)
+{
+    size_t result = 0;
+    const uint16_t num_entities = provizio_get_protocol_field_uint16_t(&header->num_entities_in_packet);
+
+    if (num_entities > PROVIZIO__MAX_RADAR_ENTITIES_PER_UDP_PACKET)
+    {
+        provizio_warning("provizio_radar_entities_packet_size: num_entities_in_packet exceeds "
+                         "PROVIZIO__MAX_RADAR_ENTITIES_PER_UDP_PACKET!");
+    }
+    else
+    {
+        result = sizeof(provizio_radar_entities_packet_header) + (sizeof(provizio_radar_entity) * num_entities);
+    }
+
+    return result;
+}
+
+void provizio_radar_entities_api_context_init(provizio_radar_entities_callback callback, void *user_data,
+                                              provizio_radar_entities_api_context *context)
+{
+    memset(context, 0, sizeof(provizio_radar_entities_api_context));
+
+    context->callback = callback;
+    context->user_data = user_data;
+    context->radar_position_id = provizio_radar_position_unknown;
+}
+
+void provizio_radar_entities_api_contexts_init(provizio_radar_entities_callback callback, void *user_data,
+                                               provizio_radar_entities_api_context *contexts, size_t num_contexts)
+{
+#pragma unroll(5)
+    for (size_t i = 0; i < num_contexts; ++i)
+    {
+        provizio_radar_entities_api_context_init(callback, user_data, &contexts[i]);
+    }
+}
+
+int32_t provizio_radar_entities_api_context_assign(provizio_radar_entities_api_context *context,
+                                                   provizio_radar_position radar_position_id)
+{
+    if (radar_position_id == provizio_radar_position_unknown)
+    {
+        provizio_error("provizio_radar_entities_api_context_assign: can't assign to provizio_radar_position_unknown");
+        return PROVIZIO_E_ARGUMENT;
+    }
+
+    if (context->radar_position_id == radar_position_id)
+    {
+        return 0;
+    }
+
+    if (context->radar_position_id == provizio_radar_position_unknown)
+    {
+        context->radar_position_id = radar_position_id;
+        return 0;
+    }
+
+    provizio_error("provizio_radar_entities_api_context_assign: already assigned");
+    return PROVIZIO_E_NOT_SUPPORTED;
+}
+
+int32_t provizio_check_radar_entities_packet(provizio_radar_entities_packet *packet, size_t packet_size)
+{
+    if (packet_size < sizeof(provizio_radar_api_protocol_header))
+    {
+        provizio_error("provizio_check_radar_entities_packet: insufficient packet_size");
+        return PROVIZIO_E_PROTOCOL;
+    }
+
+    if (provizio_get_protocol_field_uint16_t(&packet->header.protocol_header.packet_type) !=
+        PROVIZIO__RADAR_API_ENTITIES_PACKET_TYPE)
+    {
+        provizio_error("provizio_check_radar_entities_packet: unexpected packet_type");
+        return PROVIZIO_E_PROTOCOL;
+    }
+
+    if (provizio_get_protocol_field_uint16_t(&packet->header.protocol_header.protocol_version) >
+        PROVIZIO__RADAR_API_ENTITY_PROTOCOL_VERSION)
+    {
+        provizio_error("provizio_check_radar_entities_packet: Incompatible protocol version");
+        return PROVIZIO_E_PROTOCOL;
+    }
+
+    if (packet_size < sizeof(provizio_radar_entities_packet_header))
+    {
+        provizio_error("provizio_check_radar_entities_packet: insufficient packet_size");
+        return PROVIZIO_E_PROTOCOL;
+    }
+
+    const size_t expected_packet_size = provizio_radar_entities_packet_size(&packet->header);
+    if (expected_packet_size == 0)
+    {
+        provizio_error("provizio_check_radar_entities_packet: incorrect num_entities_in_packet");
+        return PROVIZIO_E_PROTOCOL;
+    }
+
+    if (packet_size != expected_packet_size)
+    {
+        provizio_error("provizio_check_radar_entities_packet: incorrect packet_size");
+        return PROVIZIO_E_PROTOCOL;
+    }
+
+    if (provizio_get_protocol_field_uint16_t(&packet->header.radar_position_id) == provizio_radar_position_unknown)
+    {
+        provizio_error("provizio_check_radar_entities_packet: the value of radar_position_id can't be "
+                       "provizio_radar_position_unknown");
+        return PROVIZIO_E_PROTOCOL;
+    }
+
+    const uint16_t total_entities_in_frame =
+        provizio_get_protocol_field_uint16_t(&packet->header.total_entities_in_frame);
+    if (total_entities_in_frame > PROVIZIO__MAX_RADAR_ENTITIES_PER_FRAME)
+    {
+        provizio_error("provizio_check_radar_entities_packet: total_entities_in_frame exceeds "
+                       "PROVIZIO__MAX_RADAR_ENTITIES_PER_FRAME");
+        return PROVIZIO_E_PROTOCOL;
+    }
+
+    const uint16_t num_entities_in_packet =
+        provizio_get_protocol_field_uint16_t(&packet->header.num_entities_in_packet);
+    if (num_entities_in_packet > total_entities_in_frame)
+    {
+        provizio_error("provizio_check_radar_entities_packet: num_entities_in_packet exceeds total_entities_in_frame");
+        return PROVIZIO_E_PROTOCOL;
+    }
+
+    return 0;
+}
+
+int32_t provizio_check_for_too_many_entities(provizio_radar_entities_frame *frame,
+                                             const uint16_t num_entities_in_packet)
+{
+    if ((uint32_t)frame->num_entities_received + (uint32_t)num_entities_in_packet >
+        (uint32_t)frame->num_entities_expected)
+    {
+        provizio_error("provizio_check_for_too_many_entities: Too many entities received");
+        return PROVIZIO_E_PROTOCOL;
+    }
+
+    provizio_verbose("provizio_check_for_too_many_entities: OK");
+    return 0;
+}
+
+int32_t provizio_handle_entities_packet_checked(provizio_radar_entities_api_context *context,
+                                                provizio_radar_entities_packet *packet)
+{
+    provizio_radar_entities_frame *frame = provizio_get_entities_frame_being_received(context, &packet->header);
+    if (!frame)
+    {
+        return PROVIZIO_E_SKIPPED;
+    }
+
+    if (provizio_get_protocol_field_uint16_t(&packet->header.total_entities_in_frame) == 0)
+    {
+        provizio_verbose("provizio_handle_entities_packet_checked: Empty frame");
+        return PROVIZIO_E_SKIPPED;
+    }
+
+    const uint16_t num_entities_in_packet =
+        provizio_get_protocol_field_uint16_t(&packet->header.num_entities_in_packet);
+
+    const int32_t status = provizio_check_for_too_many_entities(frame, num_entities_in_packet);
+    if (status != 0)
+    {
+        return status;
+    }
+
+    provizio_radar_entity *output_to = &frame->radar_entities[frame->num_entities_received];
+
+    for (uint16_t i = 0; i < num_entities_in_packet; ++i)
+    {
+        provizio_radar_entity *out_entity = output_to + i;
+        const provizio_radar_entity *in_entity = &packet->radar_entities[i];
+
+        out_entity->entity_id = provizio_get_protocol_field_uint32_t(&in_entity->entity_id);
+        out_entity->x_meters = provizio_get_protocol_field_float(&in_entity->x_meters);
+        out_entity->y_meters = provizio_get_protocol_field_float(&in_entity->y_meters);
+        out_entity->z_meters = provizio_get_protocol_field_float(&in_entity->z_meters);
+        out_entity->radar_relative_radial_velocity_m_s =
+            provizio_get_protocol_field_float(&in_entity->radar_relative_radial_velocity_m_s);
+        out_entity->ground_relative_radial_velocity_m_s =
+            provizio_get_protocol_field_float(&in_entity->ground_relative_radial_velocity_m_s);
+        out_entity->orientation.w = provizio_get_protocol_field_float(&in_entity->orientation.w);
+        out_entity->orientation.x = provizio_get_protocol_field_float(&in_entity->orientation.x);
+        out_entity->orientation.y = provizio_get_protocol_field_float(&in_entity->orientation.y);
+        out_entity->orientation.z = provizio_get_protocol_field_float(&in_entity->orientation.z);
+        out_entity->entity_class = provizio_get_protocol_field_uint8_t(&in_entity->entity_class);
+        out_entity->entity_confidence = provizio_get_protocol_field_uint8_t(&in_entity->entity_confidence);
+        out_entity->entity_class_confidence = provizio_get_protocol_field_uint8_t(&in_entity->entity_class_confidence);
+        out_entity->reserved = provizio_get_protocol_field_uint8_t(&in_entity->reserved);
+    }
+
+    frame->num_entities_received += num_entities_in_packet;
+
+    if (frame->num_entities_received == frame->num_entities_expected)
+    {
+        provizio_verbose("provizio_handle_entities_packet_checked: Return complete entities frame");
+        provizio_return_entities_frame(context, frame);
+    }
+    else
+    {
+        provizio_verbose("provizio_handle_entities_packet_checked: Success, but incomplete yet");
+    }
+
+    return 0;
+}
+
+int32_t provizio_handle_entities_packet(provizio_radar_entities_api_context *context,
+                                        provizio_radar_entities_packet *packet, size_t packet_size)
+{
+    const int32_t check_status = provizio_check_radar_entities_packet(packet, packet_size);
+    if (check_status != 0)
+    {
+        provizio_verbose("provizio_handle_entities_packet: Packet check failed");
+        return check_status;
+    }
+
+    return provizio_handle_entities_packet_checked(context, packet);
+}
+
+provizio_radar_entities_api_context *provizio_get_radar_entities_api_context_by_position_id(
+    provizio_radar_entities_api_context *contexts, size_t num_contexts, provizio_radar_entities_packet *packet)
+{
+    const uint16_t radar_position_id = provizio_get_protocol_field_uint16_t(&packet->header.radar_position_id);
+    assert(radar_position_id != provizio_radar_position_unknown);
+
+#pragma unroll(5)
+    for (size_t i = 0; i < num_contexts; ++i)
+    {
+        if (contexts[i].radar_position_id == radar_position_id)
+        {
+            return &contexts[i];
+        }
+    }
+
+#pragma unroll(5)
+    for (size_t i = 0; i < num_contexts; ++i)
+    {
+        if (contexts[i].radar_position_id == provizio_radar_position_unknown)
+        {
+            return &contexts[i];
+        }
+    }
+
+    provizio_error("provizio_get_radar_entities_api_context_by_position_id: Out of available contexts");
+    return NULL;
+}
+
+int32_t provizio_handle_radars_entities_packet(provizio_radar_entities_api_context *contexts, size_t num_contexts,
+                                               provizio_radar_entities_packet *packet, size_t packet_size)
+{
+    const int32_t check_status = provizio_check_radar_entities_packet(packet, packet_size);
+    if (check_status != 0)
+    {
+        provizio_verbose("provizio_handle_radars_entities_packet: Packet check failed");
+        return check_status;
+    }
+
+    provizio_radar_entities_api_context *context =
+        provizio_get_radar_entities_api_context_by_position_id(contexts, num_contexts, packet);
+
+    if (!context)
+    {
+        return PROVIZIO_E_OUT_OF_CONTEXTS;
+    }
+
+    return provizio_handle_entities_packet_checked(context, packet);
+}
+
+int32_t provizio_handle_possible_radar_entities_packet(provizio_radar_entities_api_context *context,
+                                                       const void *payload, size_t payload_size)
+{
+    return provizio_handle_possible_radars_entities_packet(context, 1, payload, payload_size);
+}
+
+int32_t provizio_handle_possible_radars_entities_packet(provizio_radar_entities_api_context *contexts,
+                                                        size_t num_contexts, const void *payload, size_t payload_size)
+{
+    if (payload_size < sizeof(provizio_radar_entities_packet_header))
+    {
+        provizio_verbose("provizio_handle_possible_radars_entities_packet: Not enough data");
+        return PROVIZIO_E_SKIPPED;
+    }
+
+    provizio_radar_entities_packet_header *packet_header = (provizio_radar_entities_packet_header *)payload;
+    if (provizio_get_protocol_field_uint16_t(&packet_header->protocol_header.packet_type) !=
+        PROVIZIO__RADAR_API_ENTITIES_PACKET_TYPE)
+    {
+        provizio_verbose("provizio_handle_possible_radars_entities_packet: Non-entities packet");
+        return PROVIZIO_E_SKIPPED;
+    }
+
+    if (provizio_get_protocol_field_uint16_t(&packet_header->protocol_header.protocol_version) >
+        PROVIZIO__RADAR_API_ENTITY_PROTOCOL_VERSION)
+    {
+        provizio_error("provizio_handle_possible_radars_entities_packet: Incompatible protocol version");
+        return PROVIZIO_E_PROTOCOL;
+    }
+
+    return num_contexts != 1
+               ? provizio_handle_radars_entities_packet(contexts, num_contexts,
+                                                        (provizio_radar_entities_packet *)payload, payload_size)
+               : provizio_handle_entities_packet(contexts, (provizio_radar_entities_packet *)payload, payload_size);
+}

--- a/src/quaternion.c
+++ b/src/quaternion.c
@@ -1,0 +1,49 @@
+// Copyright 2025 Provizio Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <math.h>
+
+#include "provizio/quaternion.h"
+
+void provizio_quaternion_set_identity(provizio_quaternion *out_quaternion)
+{
+    out_quaternion->w = 1.0F;
+    out_quaternion->x = 0.0F;
+    out_quaternion->y = 0.0F;
+    out_quaternion->z = 0.0F;
+}
+
+void provizio_quaternion_set_euler_angles(float x_rad, float y_rad, float z_rad, provizio_quaternion *out_quaternion)
+{
+    const float half = 0.5F;
+    const float cos_half_x = cosf(x_rad * half);
+    const float sin_half_x = sinf(x_rad * half);
+    const float cos_half_y = cosf(y_rad * half);
+    const float sin_half_y = sinf(y_rad * half);
+    const float cos_half_z = cosf(z_rad * half);
+    const float sin_half_z = sinf(z_rad * half);
+
+    out_quaternion->w = (cos_half_x * cos_half_y * cos_half_z) + (sin_half_x * sin_half_y * sin_half_z);
+    out_quaternion->x = (sin_half_x * cos_half_y * cos_half_z) - (cos_half_x * sin_half_y * sin_half_z);
+    out_quaternion->y = (cos_half_x * sin_half_y * cos_half_z) + (sin_half_x * cos_half_y * sin_half_z);
+    out_quaternion->z = (cos_half_x * cos_half_y * sin_half_z) - (sin_half_x * sin_half_y * cos_half_z);
+}
+
+uint8_t provizio_quaternion_is_valid_rotation(const provizio_quaternion *quaternion)
+{
+    const float epsilon = 0.0001F;
+    const float squared_length = (quaternion->w * quaternion->w) + (quaternion->x * quaternion->x) +
+                                 (quaternion->y * quaternion->y) + (quaternion->z * quaternion->z);
+    return 1.0F - epsilon < squared_length && squared_length < 1.0F + epsilon;
+}

--- a/src/radar_point_cloud.c
+++ b/src/radar_point_cloud.c
@@ -63,7 +63,7 @@ provizio_radar_point_cloud *provizio_get_point_cloud_being_received(
     provizio_radar_point_cloud_api_context *context, provizio_radar_point_cloud_packet_header *packet_header)
 {
     const uint32_t small_frame_index_cap = 0x0000ffff;
-    const uint32_t large_frame_index_threashold = 0xffff0000;
+    const uint32_t large_frame_index_threshold = 0xffff0000;
 
     provizio_radar_point_cloud *point_cloud = NULL;
 
@@ -72,7 +72,7 @@ provizio_radar_point_cloud *provizio_get_point_cloud_being_received(
     const uint16_t total_points_in_frame = provizio_get_protocol_field_uint16_t(&packet_header->total_points_in_frame);
     const uint16_t radar_range = provizio_get_protocol_field_uint16_t(&packet_header->radar_range);
 
-    if (frame_index < small_frame_index_cap && context->impl.latest_frame > large_frame_index_threashold)
+    if (frame_index < small_frame_index_cap && context->impl.latest_frame > large_frame_index_threshold)
     {
         // A very special case: frame indices seem to have exceeded the 0xffffffff and have been reset. Let's reset the
         // state of the API to avoid complicated state-related issues.
@@ -185,7 +185,7 @@ size_t provizio_radar_point_cloud_packet_size(const provizio_radar_point_cloud_p
     }
     else
     {
-        result = sizeof(provizio_radar_point_cloud_packet_header) + sizeof(provizio_radar_point) * num_points;
+        result = sizeof(provizio_radar_point_cloud_packet_header) + (sizeof(provizio_radar_point) * num_points);
     }
 
     return result;

--- a/src/radar_point_cloud.c
+++ b/src/radar_point_cloud.c
@@ -395,18 +395,15 @@ int32_t provizio_handle_radar_point_cloud_packet_checked(provizio_radar_point_cl
     }
 
 #ifdef PROVIZIO__AVOID_PACKETS_DUPLICATION
-    if (cloud->num_points_received >= num_points_in_packet)
+    for (uint16_t past_packet_start = 0; past_packet_start + num_points_in_packet <= cloud->num_points_received;
+         ++past_packet_start)
     {
-        for (uint16_t past_packet_start = 0, max_past_packet_start = cloud->num_points_received - num_points_in_packet;
-             past_packet_start <= max_past_packet_start; ++past_packet_start)
+        provizio_radar_point *packet_in_cloud = &cloud->radar_points[past_packet_start];
+        if (memcmp(packet_in_cloud, output_buffer, sizeof(provizio_radar_point) * num_points_in_packet) == 0)
         {
-            provizio_radar_point *packet_in_cloud = &cloud->radar_points[past_packet_start];
-            if (memcmp(packet_in_cloud, output_buffer, sizeof(provizio_radar_point) * num_points_in_packet) == 0)
-            {
-                // Drop the duplication
-                provizio_verbose("provizio_handle_radar_point_cloud_packet_checked: Packet dropped as duplicated");
-                return PROVIZIO_E_SKIPPED;
-            }
+            // Drop the duplication
+            provizio_verbose("provizio_handle_radar_point_cloud_packet_checked: Packet dropped as duplicated");
+            return PROVIZIO_E_SKIPPED;
         }
     }
 
@@ -418,7 +415,7 @@ int32_t provizio_handle_radar_point_cloud_packet_checked(provizio_radar_point_cl
         }
     }
 
-    memcpy(&cloud->radar_points[cloud->num_points_received], output_buffer,
+    memcpy(&cloud->radar_points[cloud->num_points_received], output_to,
            sizeof(provizio_radar_point) * num_points_in_packet);
 #endif
 

--- a/src/radar_points_accumulation.c
+++ b/src/radar_points_accumulation.c
@@ -191,11 +191,10 @@ provizio_accumulated_radar_point_cloud_iterator provizio_accumulate_radar_point_
         accumulated_point_clouds[iterator.point_cloud_index].point_cloud.frame_index >= point_cloud->frame_index)
     {
         const uint32_t small_frame_index_cap = 0x0000ffff;
-        const uint32_t large_frame_index_threashold = 0xffff0000;
+        const uint32_t large_frame_index_threshold = 0xffff0000;
 
         if (point_cloud->frame_index >= small_frame_index_cap ||
-            accumulated_point_clouds[iterator.point_cloud_index].point_cloud.frame_index <=
-                large_frame_index_threashold)
+            accumulated_point_clouds[iterator.point_cloud_index].point_cloud.frame_index <= large_frame_index_threshold)
         {
             provizio_error(
                 "provizio_accumulate_radar_point_cloud: Can't accumulate an older point cloud after a newer one");

--- a/src/radar_points_accumulation_filters.c
+++ b/src/radar_points_accumulation_filters.c
@@ -63,8 +63,8 @@ static float provizio_estimate_radars_forward_velocity_using_velocities_histogra
     {
         const float half = 0.5F;
         const float average_velocity = (max_velocity + min_velocity) * half;
-        min_velocity = average_velocity - min_velocities_range * half;
-        max_velocity = average_velocity + min_velocities_range * half;
+        min_velocity = average_velocity - (min_velocities_range * half);
+        max_velocity = average_velocity + (min_velocities_range * half);
     }
 
     const float bin_size = (max_velocity - min_velocity) / histogram_bins;
@@ -174,7 +174,7 @@ static float provizio_estimate_radars_forward_velocity(
                 const float ego_direction_up = current_fix.position.up_meters - previous_position.up_meters;
 
                 provizio_quaternion ego_orientation;
-                if (ego_direction_north * ego_direction_north + ego_direction_east * ego_direction_east > 0)
+                if ((ego_direction_north * ego_direction_north) + (ego_direction_east * ego_direction_east) > 0)
                 {
                     const float yaw = atan2f(ego_direction_north, ego_direction_east);
                     const float pitch =
@@ -236,7 +236,7 @@ void provizio_radar_points_accumulation_filter_static(
 {
     (void)user_data;
 
-    const float dynamic_velocity_threashold_m_s = 1.5F;
+    const float dynamic_velocity_threshold_m_s = 1.5F;
     const float radars_forward_velocity_m_s = provizio_estimate_radars_forward_velocity(
         in_points, num_in_points, accumulated_point_clouds, num_accumulated_point_clouds, new_iterator);
 
@@ -246,9 +246,9 @@ void provizio_radar_points_accumulation_filter_static(
         // TODO(APT-1667): dynamic adjustment of ground-relative velocity accounting for angular differences of
         // detections
         // if (fabsf(point->radar_relative_radial_velocity_m_s + radars_forward_velocity_m_s *
-        // cosf(atan2f(point->y_meters, point->x_meters) * -1)) < dynamic_velocity_threashold_m_s)
+        // cosf(atan2f(point->y_meters, point->x_meters) * -1)) < dynamic_velocity_threshold_m_s)
         if (fabsf(point->radar_relative_radial_velocity_m_s + radars_forward_velocity_m_s) <
-            dynamic_velocity_threashold_m_s)
+            dynamic_velocity_threshold_m_s)
         {
             // Static point, let's accumulate it
             out_points[num_filtered_points++] = *point;

--- a/src/radar_points_accumulation_types.c
+++ b/src/radar_points_accumulation_types.c
@@ -16,38 +16,6 @@
 
 #include <math.h>
 
-void provizio_quaternion_set_identity(provizio_quaternion *out_quaternion)
-{
-    out_quaternion->w = 1.0F;
-    out_quaternion->x = 0.0F;
-    out_quaternion->y = 0.0F;
-    out_quaternion->z = 0.0F;
-}
-
-void provizio_quaternion_set_euler_angles(float x_rad, float y_rad, float z_rad, provizio_quaternion *out_quaternion)
-{
-    const float half = 0.5F;
-    const float cos_half_x = cosf(x_rad * half);
-    const float sin_half_x = sinf(x_rad * half);
-    const float cos_half_y = cosf(y_rad * half);
-    const float sin_half_y = sinf(y_rad * half);
-    const float cos_half_z = cosf(z_rad * half);
-    const float sin_half_z = sinf(z_rad * half);
-
-    out_quaternion->w = (cos_half_x * cos_half_y * cos_half_z) + (sin_half_x * sin_half_y * sin_half_z);
-    out_quaternion->x = (sin_half_x * cos_half_y * cos_half_z) - (cos_half_x * sin_half_y * sin_half_z);
-    out_quaternion->y = (cos_half_x * sin_half_y * cos_half_z) + (sin_half_x * cos_half_y * sin_half_z);
-    out_quaternion->z = (cos_half_x * cos_half_y * sin_half_z) - (sin_half_x * sin_half_y * cos_half_z);
-}
-
-uint8_t provizio_quaternion_is_valid_rotation(const provizio_quaternion *quaternion)
-{
-    const float epsilon = 0.0001F;
-    const float squared_length = (quaternion->w * quaternion->w) + (quaternion->x * quaternion->x) +
-                                 (quaternion->y * quaternion->y) + (quaternion->z * quaternion->z);
-    return 1.0F - epsilon < squared_length && squared_length < 1.0F + epsilon;
-}
-
 float provizio_enu_distance(const provizio_enu_position *position_a, const provizio_enu_position *position_b)
 {
     const float diff_east = position_a->east_meters - position_b->east_meters;

--- a/test/c_99/CMakeLists.txt
+++ b/test/c_99/CMakeLists.txt
@@ -60,8 +60,10 @@ add_executable(
   provizio_radar_api_core_test_c_99
   src/test_main.c
   src/test_common.c
+  src/test_quaternion.c
   src/test_util.c
   src/test_radar_point_cloud.c
+  src/test_radar_entities.c
   src/test_radar_points_accumulation_types.c
   src/test_radar_points_accumulation_filters.c
   src/test_radar_points_accumulation.c

--- a/test/c_99/src/test_core.c
+++ b/test/c_99/src/test_core.c
@@ -14,6 +14,7 @@
 
 #include "unity/unity.h"
 
+#include <errno.h>
 #include <pthread.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -22,6 +23,8 @@
 #include "provizio/radar_api/core.h"
 #include "provizio/util.h"
 
+#include "test_entities_callbacks.h"
+#include "test_entities_helpers.h"
 #include "test_point_cloud_callbacks.h"
 
 typedef struct test_receive_packet_on_packet_sent_callback_data // NOLINT: it's aligned exactly as it's supposed to
@@ -62,12 +65,38 @@ typedef struct send_point_cloud_packet_data // NOLINT: it's aligned exactly as i
     void *user_data;
 } send_point_cloud_packet_data;
 
+typedef struct test_receive_entities_packet_on_packet_sent_callback_data
+{
+    provizio_radar_entities_api_context *contexts;
+    size_t num_contexts;
+    provizio_radar_api_connection *connection;
+} test_receive_entities_packet_on_packet_sent_callback_data;
+
+typedef int32_t (*provizio_radar_entities_packet_callback)(const provizio_radar_entities_packet *packet,
+                                                           void *user_data);
+
+typedef struct send_entities_packet_data
+{
+    PROVIZIO__SOCKET sock;
+    struct sockaddr *target_address;
+
+    provizio_radar_entities_packet_callback further_callback;
+    void *user_data;
+} send_entities_packet_data;
+
 enum
 {
     test_message_length = 1024
 };
 static char provizio_test_error[test_message_length];   // NOLINT: non-const global by design
 static char provizio_test_warning[test_message_length]; // NOLINT: non-const global by design
+
+static const float provizio_test_entities_float_tolerance = 0.0001F;
+static const float provizio_test_entities_first_x = 3.5F;
+static const float provizio_test_entities_first_y = 1.3F;
+static const float provizio_test_entities_first_z = 5.73F;
+static const float provizio_test_entities_first_w = 0.19F;
+static const float provizio_test_entities_offset_step = 1.0F;
 
 static void test_provizio_on_error(const char *error)
 {
@@ -310,6 +339,111 @@ static int32_t send_test_point_cloud(const uint16_t port, const uint32_t frame_i
     return 0;
 }
 
+static int32_t send_entities_packet(const provizio_radar_entities_packet *packet, void *user_data)
+{
+    send_entities_packet_data *data = (send_entities_packet_data *)user_data;
+
+    const int32_t sent = (int32_t)sendto(data->sock, (const char *)packet,
+                                         (uint16_t)provizio_radar_entities_packet_size(&packet->header), 0,
+                                         data->target_address, sizeof(struct sockaddr_in));
+
+    if (sent < 0)
+    {
+        // LCOV_EXCL_START: Can't be unit-tested as it depends on the state of the OS
+        provizio_error("send_test_entities: Failed to send provizio_radar_entities_packet");
+        return sent;
+        // LCOV_EXCL_STOP
+    }
+
+    if (data->further_callback)
+    {
+        return data->further_callback(packet, data->user_data);
+    }
+
+    return 0; // LCOV_EXCL_LINE: just a safety net, no need to achieve full coverage of test code
+}
+
+static int32_t send_test_entities(const uint16_t port, const uint32_t frame_index, const uint64_t timestamp,
+                                  const float x_offset, const uint16_t *radar_position_ids,
+                                  const uint16_t *radar_ranges, const size_t num_radars, const uint16_t num_entities,
+                                  provizio_radar_entities_packet_callback on_packet_sent, void *user_data)
+{
+    PROVIZIO__SOCKET sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (!provizio_socket_valid(sock))
+    {
+        // LCOV_EXCL_START: Can't be unit-tested as it depends on the state of the OS
+        const int32_t status = (int32_t)errno;
+        provizio_error("send_test_entities: Failed to create a UDP socket!");
+        return status != 0 ? status : (int32_t)-1;
+        // LCOV_EXCL_STOP
+    }
+
+    struct sockaddr_in my_address;
+    memset(&my_address, 0, sizeof(my_address));
+    my_address.sin_family = AF_INET;
+    my_address.sin_port = 0;                 // Any port
+    my_address.sin_addr.s_addr = INADDR_ANY; // Any address
+
+    int32_t status = bind(sock, (struct sockaddr *)&my_address, sizeof(my_address));
+    if (status != 0)
+    {
+        // LCOV_EXCL_START: No need to achieve 100% coverage in test code
+        provizio_error("send_test_entities: Failed to bind socket");
+        provizio_socket_close(sock);
+        return status;
+        // LCOV_EXCL_STOP
+    }
+
+    struct sockaddr_in target_address;
+    memset(&target_address, 0, sizeof(target_address));
+    target_address.sin_family = AF_INET;
+    target_address.sin_port = htons(port); // NOLINT
+    target_address.sin_addr.s_addr = inet_addr("127.0.0.1");
+
+    send_entities_packet_data send_data;
+    memset(&send_data, 0, sizeof(send_data));
+    send_data.sock = sock;
+    send_data.target_address = (struct sockaddr *)&target_address;
+    send_data.further_callback = on_packet_sent;
+    send_data.user_data = user_data;
+
+    for (size_t i = 0; i < num_radars; ++i)
+    {
+        provizio_radar_entities_packet packet;
+        status =
+            provizio_test_create_entities_packet(&packet, frame_index, timestamp, radar_position_ids[i],
+                                                 radar_ranges != NULL ? radar_ranges[i] : provizio_radar_range_unknown,
+                                                 num_entities, num_entities, x_offset + (float)i);
+        if (status != 0)
+        {
+            // LCOV_EXCL_START: Can't be unit-tested as helper always succeeds
+            provizio_socket_close(sock);
+            return status;
+            // LCOV_EXCL_STOP
+        }
+
+        status = send_entities_packet(&packet, &send_data);
+        if (status != 0)
+        {
+            // LCOV_EXCL_START: Can't be unit-tested as it depends on the state of the OS
+            provizio_socket_close(sock);
+            return status;
+            // LCOV_EXCL_STOP
+        }
+    }
+
+    status = provizio_socket_close(sock);
+    if (status != 0)
+    {
+        // LCOV_EXCL_START: Can't be unit-tested as it depends on the state of the OS
+        provizio_error("send_test_entities: Failed to close the socket");
+        return status;
+        // LCOV_EXCL_STOP
+    }
+
+    return 0;
+}
+
 static int32_t send_test_point_clouds_until_stopped(const uint16_t port, const uint32_t first_frame_index,
                                                     const uint64_t initial_timestamp, const float x_offset,
                                                     const uint16_t *radar_position_ids, const uint16_t *radar_ranges,
@@ -355,6 +489,17 @@ static int32_t test_receive_packet_on_packet_sent(const provizio_radar_point_clo
     return provizio_radar_api_receive_packet(data->connection);
 }
 
+static int32_t test_receive_entities_packet_on_packet_sent(const provizio_radar_entities_packet *packet,
+                                                           void *user_data)
+{
+    (void)packet;
+
+    test_receive_entities_packet_on_packet_sent_callback_data *data =
+        (test_receive_entities_packet_on_packet_sent_callback_data *)user_data;
+
+    return provizio_radar_api_receive_packet(data->connection);
+}
+
 static void test_receives_single_radar_point_cloud_from_single_radar(void)
 {
     const uint16_t port_number = 20000 + __LINE__ + PROVIZIO__RADAR_API_DEFAULT_PORT;
@@ -373,7 +518,7 @@ static void test_receives_single_radar_point_cloud_from_single_radar(void)
     provizio_radar_point_cloud_api_context api_context;
     provizio_radar_point_cloud_api_context_init(&test_provizio_radar_point_cloud_callback, callback_data, &api_context);
     provizio_radar_api_connection connection;
-    int32_t status = provizio_open_radar_connection(port_number, 0, 0, &api_context, &connection);
+    int32_t status = provizio_open_radar_connection(port_number, 0, 0, &api_context, NULL, &connection);
     TEST_ASSERT_EQUAL_INT32(0, status);
     TEST_ASSERT_TRUE(provizio_socket_valid(connection.sock)); // NOLINT: clang-tidy doesn't like TEST_ASSERT_TRUE
 
@@ -459,7 +604,8 @@ static void test_receives_single_radar_point_cloud_from_2_radars(void)
     provizio_radar_point_cloud_api_contexts_init(&test_provizio_radar_point_cloud_callback, callback_data, api_contexts,
                                                  num_contexts);
     provizio_radar_api_connection connection;
-    int32_t status = provizio_open_radars_connection(port_number, 0, 0, api_contexts, num_contexts, &connection);
+    int32_t status =
+        provizio_open_radars_connection(port_number, 0, 0, api_contexts, num_contexts, NULL, 0, &connection);
     TEST_ASSERT_EQUAL_INT32(0, status);
     TEST_ASSERT_TRUE(provizio_socket_valid(connection.sock)); // NOLINT: clang-tidy doesn't like TEST_ASSERT_TRUE
 
@@ -531,6 +677,126 @@ static void test_receives_single_radar_point_cloud_from_2_radars(void)
     free(callback_data);
 }
 
+static void test_receives_single_radar_entities_from_single_radar(void)
+{
+    const uint16_t port_number = 20000 + __LINE__ + PROVIZIO__RADAR_API_DEFAULT_PORT;
+    const uint32_t frame_index = 77;
+    const uint64_t timestamp = 0x0123456789abcdef;
+    const uint16_t radar_position_id = provizio_radar_position_rear_left;
+    const uint16_t radar_range = provizio_radar_range_long;
+    const uint16_t num_entities = 32;
+
+    test_provizio_radar_entities_callback_data *callback_data =
+        (test_provizio_radar_entities_callback_data *)malloc(sizeof(test_provizio_radar_entities_callback_data));
+    memset(callback_data, 0, sizeof(test_provizio_radar_entities_callback_data));
+    test_receive_entities_packet_on_packet_sent_callback_data send_test_callback_data;
+    memset(&send_test_callback_data, 0, sizeof(send_test_callback_data));
+
+    provizio_radar_entities_api_context entities_context;
+    provizio_radar_entities_api_context_init(&test_provizio_radar_entities_callback, callback_data, &entities_context);
+    provizio_radar_api_connection connection;
+    int32_t status = provizio_open_radar_connection(port_number, 0, 0, NULL, &entities_context, &connection);
+    TEST_ASSERT_EQUAL_INT32(0, status);
+    TEST_ASSERT_TRUE(provizio_socket_valid(connection.sock)); // NOLINT
+
+    send_test_callback_data.contexts = &entities_context;
+    send_test_callback_data.num_contexts = 1;
+    send_test_callback_data.connection = &connection;
+
+    status = send_test_entities(port_number, frame_index, timestamp, 0.0F, &radar_position_id, &radar_range, 1,
+                                num_entities, &test_receive_entities_packet_on_packet_sent, &send_test_callback_data);
+    TEST_ASSERT_EQUAL_INT32(0, status);
+
+    status = provizio_close_radar_connection(&connection);
+    TEST_ASSERT_EQUAL_INT32(0, status);
+
+    TEST_ASSERT_EQUAL_INT32(1, callback_data->called_times);
+    TEST_ASSERT_EQUAL_UINT32(frame_index, callback_data->last_entities_frames[0].frame_index);
+    TEST_ASSERT_EQUAL_UINT64(timestamp, callback_data->last_entities_frames[0].timestamp);
+    TEST_ASSERT_EQUAL_UINT16(radar_position_id, callback_data->last_entities_frames[0].radar_position_id);
+    TEST_ASSERT_EQUAL_UINT16(num_entities, callback_data->last_entities_frames[0].num_entities_expected);
+    TEST_ASSERT_EQUAL_UINT16(num_entities, callback_data->last_entities_frames[0].num_entities_received);
+    TEST_ASSERT_EQUAL_UINT16(radar_range, callback_data->last_entities_frames[0].radar_range);
+
+    const provizio_radar_entity *first_entity = &callback_data->last_entities_frames[0].radar_entities[0];
+    TEST_ASSERT_EQUAL_UINT32(1, first_entity->entity_id);
+    TEST_ASSERT_FLOAT_WITHIN(provizio_test_entities_float_tolerance, provizio_test_entities_first_x,
+                             first_entity->x_meters);
+    TEST_ASSERT_FLOAT_WITHIN(provizio_test_entities_float_tolerance, provizio_test_entities_first_y,
+                             first_entity->y_meters);
+    TEST_ASSERT_FLOAT_WITHIN(provizio_test_entities_float_tolerance, provizio_test_entities_first_z,
+                             first_entity->z_meters);
+    TEST_ASSERT_FLOAT_WITHIN(provizio_test_entities_float_tolerance, provizio_test_entities_first_w,
+                             first_entity->orientation.w);
+    TEST_ASSERT_EQUAL_UINT8(1, first_entity->entity_class);
+
+    free(callback_data);
+}
+
+static void test_receives_single_radar_entities_from_2_radars(void)
+{
+    const uint16_t port_number = 20000 + __LINE__ + PROVIZIO__RADAR_API_DEFAULT_PORT;
+    const uint32_t frame_index = 91;
+    const uint64_t timestamp = 0x0123012301230123;
+    const uint16_t radar_position_ids[2] = {provizio_radar_position_rear_left, provizio_radar_position_front_center};
+    const uint16_t radar_ranges[2] = {provizio_radar_range_short, provizio_radar_range_ultra_long};
+    const size_t num_radars = sizeof(radar_position_ids) / sizeof(radar_position_ids[0]);
+    const uint16_t num_entities = 24;
+
+    test_provizio_radar_entities_callback_data *callback_data =
+        (test_provizio_radar_entities_callback_data *)malloc(sizeof(test_provizio_radar_entities_callback_data));
+    memset(callback_data, 0, sizeof(test_provizio_radar_entities_callback_data));
+    test_receive_entities_packet_on_packet_sent_callback_data send_test_callback_data;
+    memset(&send_test_callback_data, 0, sizeof(send_test_callback_data));
+
+    provizio_radar_entities_api_context *entities_contexts =
+        (provizio_radar_entities_api_context *)malloc(sizeof(provizio_radar_entities_api_context) * num_radars);
+    provizio_radar_entities_api_contexts_init(&test_provizio_radar_entities_callback, callback_data, entities_contexts,
+                                              num_radars);
+    provizio_radar_api_connection connection;
+    int32_t status =
+        provizio_open_radars_connection(port_number, 0, 0, NULL, 0, entities_contexts, num_radars, &connection);
+    TEST_ASSERT_EQUAL_INT32(0, status);
+    TEST_ASSERT_TRUE(provizio_socket_valid(connection.sock)); // NOLINT
+
+    send_test_callback_data.contexts = entities_contexts;
+    send_test_callback_data.num_contexts = num_radars;
+    send_test_callback_data.connection = &connection;
+
+    status = send_test_entities(port_number, frame_index, timestamp, 0.0F, radar_position_ids, radar_ranges, num_radars,
+                                num_entities, &test_receive_entities_packet_on_packet_sent, &send_test_callback_data);
+    TEST_ASSERT_EQUAL_INT32(0, status);
+
+    status = provizio_close_radars_connection(&connection);
+    TEST_ASSERT_EQUAL_INT32(0, status);
+
+    TEST_ASSERT_EQUAL_INT32(num_radars, callback_data->called_times);
+    for (size_t i = 0; i < num_radars; ++i)
+    {
+        const size_t radar_index = num_radars - 1U - i;
+        const provizio_radar_entities_frame *frame = &callback_data->last_entities_frames[i];
+        TEST_ASSERT_EQUAL_UINT32(frame_index, frame->frame_index);
+        TEST_ASSERT_EQUAL_UINT64(timestamp, frame->timestamp);
+        TEST_ASSERT_EQUAL_UINT16(radar_position_ids[radar_index], frame->radar_position_id);
+        TEST_ASSERT_EQUAL_UINT16(radar_ranges[radar_index], frame->radar_range);
+        TEST_ASSERT_EQUAL_UINT16(num_entities, frame->num_entities_expected);
+        TEST_ASSERT_EQUAL_UINT16(num_entities, frame->num_entities_received);
+
+        const float expected_offset = provizio_test_entities_offset_step * (float)radar_index;
+        const provizio_radar_entity *first_entity = &frame->radar_entities[0];
+        TEST_ASSERT_FLOAT_WITHIN(provizio_test_entities_float_tolerance,
+                                 provizio_test_entities_first_x + expected_offset, first_entity->x_meters);
+        TEST_ASSERT_FLOAT_WITHIN(provizio_test_entities_float_tolerance, provizio_test_entities_first_y,
+                                 first_entity->y_meters);
+        TEST_ASSERT_FLOAT_WITHIN(provizio_test_entities_float_tolerance, provizio_test_entities_first_z,
+                                 first_entity->z_meters);
+        TEST_ASSERT_EQUAL_UINT8(1, first_entity->entity_class);
+    }
+
+    free(entities_contexts);
+    free(callback_data);
+}
+
 static void test_receive_radar_point_cloud_frame_indices_overflow(void)
 {
     const uint16_t port_number = 20000 + __LINE__ + PROVIZIO__RADAR_API_DEFAULT_PORT;
@@ -549,7 +815,7 @@ static void test_receive_radar_point_cloud_frame_indices_overflow(void)
     provizio_radar_point_cloud_api_context api_context;
     provizio_radar_point_cloud_api_context_init(&test_provizio_radar_point_cloud_callback, callback_data, &api_context);
     provizio_radar_api_connection connection;
-    int32_t status = provizio_open_radar_connection(port_number, 0, 0, &api_context, &connection);
+    int32_t status = provizio_open_radar_connection(port_number, 0, 0, &api_context, NULL, &connection);
     TEST_ASSERT_EQUAL_INT32(0, status);
     TEST_ASSERT_TRUE(provizio_socket_valid(connection.sock)); // NOLINT: clang-tidy doesn't like TEST_ASSERT_TRUE
 
@@ -610,7 +876,7 @@ static void test_receive_radar_point_cloud_frame_position_ids_mismatch(void)
     provizio_radar_point_cloud_api_context api_context;
     provizio_radar_point_cloud_api_context_init(&test_provizio_radar_point_cloud_callback, callback_data, &api_context);
     provizio_radar_api_connection connection;
-    int32_t status = provizio_open_radar_connection(port_number, 0, 0, &api_context, &connection);
+    int32_t status = provizio_open_radar_connection(port_number, 0, 0, &api_context, NULL, &connection);
     TEST_ASSERT_EQUAL_INT32(0, status);
     TEST_ASSERT_TRUE(provizio_socket_valid(connection.sock)); // NOLINT: clang-tidy doesn't like TEST_ASSERT_TRUE
 
@@ -660,7 +926,7 @@ static void test_receive_radar_point_cloud_drop_obsolete_incomplete_frame(void)
     provizio_radar_point_cloud_api_context api_context;
     provizio_radar_point_cloud_api_context_init(&test_provizio_radar_point_cloud_callback, callback_data, &api_context);
     provizio_radar_api_connection connection;
-    int32_t status = provizio_open_radar_connection(port_number, 0, 0, &api_context, &connection);
+    int32_t status = provizio_open_radar_connection(port_number, 0, 0, &api_context, NULL, &connection);
     TEST_ASSERT_EQUAL_INT32(0, status);
     TEST_ASSERT_TRUE(provizio_socket_valid(connection.sock)); // NOLINT: clang-tidy doesn't like TEST_ASSERT_TRUE
 
@@ -702,7 +968,7 @@ static void test_receive_radar_point_cloud_too_many_points(void)
     provizio_radar_point_cloud_api_context api_context;
     provizio_radar_point_cloud_api_context_init(NULL, NULL, &api_context);
     provizio_radar_api_connection connection;
-    int32_t status = provizio_open_radar_connection(port_number, 0, 0, &api_context, &connection);
+    int32_t status = provizio_open_radar_connection(port_number, 0, 0, &api_context, NULL, &connection);
     TEST_ASSERT_EQUAL_INT32(0, status);
     TEST_ASSERT_TRUE(provizio_socket_valid(connection.sock)); // NOLINT: clang-tidy doesn't like TEST_ASSERT_TRUE
 
@@ -757,7 +1023,8 @@ static void test_receive_radar_point_cloud_not_enough_contexts(void)
     provizio_radar_point_cloud_api_contexts_init(&test_provizio_radar_point_cloud_callback, callback_data, api_contexts,
                                                  num_contexts);
     provizio_radar_api_connection connection;
-    int32_t status = provizio_open_radars_connection(port_number, 0, 0, api_contexts, num_contexts, &connection);
+    int32_t status =
+        provizio_open_radars_connection(port_number, 0, 0, api_contexts, num_contexts, NULL, 0, &connection);
     TEST_ASSERT_EQUAL_INT32(0, status);
     TEST_ASSERT_TRUE(provizio_socket_valid(connection.sock)); // NOLINT: clang-tidy doesn't like TEST_ASSERT_TRUE
 
@@ -817,7 +1084,7 @@ static void test_receive_radar_point_cloud_timeout_ok(void)
 
     provizio_radar_api_connection connection;
     TEST_ASSERT_EQUAL_INT32(
-        0, provizio_open_radar_connection(port_number, receive_timeout_ns, 1, &api_context, &connection));
+        0, provizio_open_radar_connection(port_number, receive_timeout_ns, 1, &api_context, NULL, &connection));
 
     while (callback_data->called_times == 0) // NOLINT: No need to unroll
     {
@@ -859,7 +1126,7 @@ static void test_receive_radar_point_cloud_timeout_fails(void)
     TEST_ASSERT_EQUAL_INT32(0, provizio_gettimeofday(&time_was));
     provizio_radar_api_connection connection;
     TEST_ASSERT_EQUAL_INT32(PROVIZIO_E_TIMEOUT, provizio_open_radar_connection(port_number, receive_timeout_ns, 1,
-                                                                               &api_context, &connection));
+                                                                               &api_context, NULL, &connection));
     TEST_ASSERT_EQUAL_INT32(0, provizio_gettimeofday(&time_now));
     int32_t took_time_ms = (int32_t)(((time_now.tv_sec - time_was.tv_sec) * thousand) +
                                      ((time_now.tv_usec - time_was.tv_usec) / thousand));
@@ -868,7 +1135,7 @@ static void test_receive_radar_point_cloud_timeout_fails(void)
 
     // It doesn't fail when checking connection is disabled
     TEST_ASSERT_EQUAL_INT32(
-        0, provizio_open_radar_connection(port_number, receive_timeout_ns, 0, &api_context, &connection));
+        0, provizio_open_radar_connection(port_number, receive_timeout_ns, 0, &api_context, NULL, &connection));
 
     // But fails to receive on time, when requested
     TEST_ASSERT_EQUAL_INT32(0, provizio_gettimeofday(&time_was));
@@ -1131,6 +1398,9 @@ static void test_provizio_set_radar_range_ok(void)
 
 static void test_provizio_set_radar_range_broadcasting_ok(void)
 {
+#if defined(__APPLE__) && defined(__MACH__)
+    TEST_IGNORE_MESSAGE("macOS doesn't allow broadcasting to 255.255.255.255");
+#else
     const uint16_t port_number = 20000 + __LINE__ + PROVIZIO__RADAR_API_DEFAULT_PORT;
     const provizio_radar_position radar_position_id = provizio_radar_position_rear_right;
     const provizio_radar_range range = provizio_radar_range_long;
@@ -1159,8 +1429,10 @@ static void test_provizio_set_radar_range_broadcasting_ok(void)
     wait_till_test_provizio_set_radar_range_radar_thread_ready(&thread_data);
 
     provizio_radar_range actual_radar_range = provizio_radar_range_hyper_long;
-    TEST_ASSERT_EQUAL(
-        0, provizio_set_radar_range(radar_position_id, range, port_number, "255.255.255.255", &actual_radar_range));
+    const int32_t status =
+        provizio_set_radar_range(radar_position_id, range, port_number, "255.255.255.255", &actual_radar_range);
+
+    TEST_ASSERT_EQUAL(0, status);
 
     TEST_ASSERT_EQUAL(0, pthread_join(radar_thread, NULL));
     TEST_ASSERT_EQUAL(0, pthread_mutex_destroy(&mutex));
@@ -1174,6 +1446,7 @@ static void test_provizio_set_radar_range_broadcasting_ok(void)
                       provizio_get_protocol_field_uint16_t(&thread_data.requested_packet.radar_position_id));
     TEST_ASSERT_EQUAL((uint16_t)range, provizio_get_protocol_field_uint16_t(&thread_data.requested_packet.radar_range));
     TEST_ASSERT_EQUAL((uint16_t)range, actual_radar_range);
+#endif
 }
 
 static void test_provizio_set_radar_range_unknown_range(void)
@@ -1770,7 +2043,7 @@ static void test_duplicated_packets(void)
     provizio_radar_point_cloud_api_context api_context;
     provizio_radar_point_cloud_api_context_init(NULL, NULL, &api_context);
     provizio_radar_api_connection connection;
-    int32_t status = provizio_open_radar_connection(port_number, 0, 0, &api_context, &connection);
+    int32_t status = provizio_open_radar_connection(port_number, 0, 0, &api_context, NULL, &connection);
     TEST_ASSERT_EQUAL_INT32(0, status);
     TEST_ASSERT_TRUE(provizio_socket_valid(connection.sock)); // NOLINT: clang-tidy doesn't like TEST_ASSERT_TRUE
 
@@ -1814,6 +2087,8 @@ int provizio_run_test_core(void)
 
     RUN_TEST(test_receives_single_radar_point_cloud_from_single_radar);
     RUN_TEST(test_receives_single_radar_point_cloud_from_2_radars);
+    RUN_TEST(test_receives_single_radar_entities_from_single_radar);
+    RUN_TEST(test_receives_single_radar_entities_from_2_radars);
     RUN_TEST(test_receive_radar_point_cloud_frame_indices_overflow);
     RUN_TEST(test_receive_radar_point_cloud_frame_position_ids_mismatch);
     RUN_TEST(test_receive_radar_point_cloud_drop_obsolete_incomplete_frame);

--- a/test/c_99/src/test_core.c
+++ b/test/c_99/src/test_core.c
@@ -95,8 +95,17 @@ static const float provizio_test_entities_float_tolerance = 0.0001F;
 static const float provizio_test_entities_first_x = 3.5F;
 static const float provizio_test_entities_first_y = 1.3F;
 static const float provizio_test_entities_first_z = 5.73F;
-static const float provizio_test_entities_first_w = 0.19F;
+static const float provizio_test_entities_first_orientation_w = 0.69F;
+static const float provizio_test_entities_first_orientation_x = 0.44F;
+static const float provizio_test_entities_first_orientation_y = -0.06F;
+static const float provizio_test_entities_first_orientation_z = -0.31F;
+static const float provizio_test_entities_first_size_x = 11.725F;
+static const float provizio_test_entities_first_size_y = 10.125F;
+static const float provizio_test_entities_first_size_z = 13.325F;
 static const float provizio_test_entities_offset_step = 1.0F;
+static const uint8_t provizio_test_entities_first_entity_class = 1;
+static const uint8_t provizio_test_entities_first_entity_confidence = 50;
+static const uint8_t provizio_test_entities_first_entity_class_confidence = 60;
 
 static void test_provizio_on_error(const char *error)
 {
@@ -366,8 +375,14 @@ static int32_t send_entities_packet(const provizio_radar_entities_packet *packet
 static int32_t send_test_entities(const uint16_t port, const uint32_t frame_index, const uint64_t timestamp,
                                   const float x_offset, const uint16_t *radar_position_ids,
                                   const uint16_t *radar_ranges, const size_t num_radars, const uint16_t num_entities,
+                                  const uint16_t num_entities_in_packet,
                                   provizio_radar_entities_packet_callback on_packet_sent, void *user_data)
 {
+    if (num_entities_in_packet > num_entities)
+    {
+        return PROVIZIO_E_ARGUMENT; // LCOV_EXCL_LINE: just a safety net, no need to achieve full coverage of test code
+    }
+
     PROVIZIO__SOCKET sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
     if (!provizio_socket_valid(sock))
     {
@@ -413,7 +428,7 @@ static int32_t send_test_entities(const uint16_t port, const uint32_t frame_inde
         status =
             provizio_test_create_entities_packet(&packet, frame_index, timestamp, radar_position_ids[i],
                                                  radar_ranges != NULL ? radar_ranges[i] : provizio_radar_range_unknown,
-                                                 num_entities, num_entities, x_offset + (float)i);
+                                                 num_entities, num_entities_in_packet, x_offset + (float)i);
         if (status != 0)
         {
             // LCOV_EXCL_START: Can't be unit-tested as helper always succeeds
@@ -684,7 +699,7 @@ static void test_receives_single_radar_entities_from_single_radar(void)
     const uint64_t timestamp = 0x0123456789abcdef;
     const uint16_t radar_position_id = provizio_radar_position_rear_left;
     const uint16_t radar_range = provizio_radar_range_long;
-    const uint16_t num_entities = 32;
+    const uint16_t num_entities = 24;
 
     test_provizio_radar_entities_callback_data *callback_data =
         (test_provizio_radar_entities_callback_data *)malloc(sizeof(test_provizio_radar_entities_callback_data));
@@ -703,8 +718,9 @@ static void test_receives_single_radar_entities_from_single_radar(void)
     send_test_callback_data.num_contexts = 1;
     send_test_callback_data.connection = &connection;
 
-    status = send_test_entities(port_number, frame_index, timestamp, 0.0F, &radar_position_id, &radar_range, 1,
-                                num_entities, &test_receive_entities_packet_on_packet_sent, &send_test_callback_data);
+    status =
+        send_test_entities(port_number, frame_index, timestamp, 0.0F, &radar_position_id, &radar_range, 1, num_entities,
+                           num_entities, &test_receive_entities_packet_on_packet_sent, &send_test_callback_data);
     TEST_ASSERT_EQUAL_INT32(0, status);
 
     status = provizio_close_radar_connection(&connection);
@@ -726,9 +742,24 @@ static void test_receives_single_radar_entities_from_single_radar(void)
                              first_entity->y_meters);
     TEST_ASSERT_FLOAT_WITHIN(provizio_test_entities_float_tolerance, provizio_test_entities_first_z,
                              first_entity->z_meters);
-    TEST_ASSERT_FLOAT_WITHIN(provizio_test_entities_float_tolerance, provizio_test_entities_first_w,
+    TEST_ASSERT_FLOAT_WITHIN(provizio_test_entities_float_tolerance, provizio_test_entities_first_orientation_x,
+                             first_entity->orientation.x);
+    TEST_ASSERT_FLOAT_WITHIN(provizio_test_entities_float_tolerance, provizio_test_entities_first_orientation_y,
+                             first_entity->orientation.y);
+    TEST_ASSERT_FLOAT_WITHIN(provizio_test_entities_float_tolerance, provizio_test_entities_first_orientation_z,
+                             first_entity->orientation.z);
+    TEST_ASSERT_FLOAT_WITHIN(provizio_test_entities_float_tolerance, provizio_test_entities_first_orientation_w,
                              first_entity->orientation.w);
-    TEST_ASSERT_EQUAL_UINT8(1, first_entity->entity_class);
+    TEST_ASSERT_FLOAT_WITHIN(provizio_test_entities_float_tolerance, provizio_test_entities_first_size_x,
+                             first_entity->size.x_meters);
+    TEST_ASSERT_FLOAT_WITHIN(provizio_test_entities_float_tolerance, provizio_test_entities_first_size_y,
+                             first_entity->size.y_meters);
+    TEST_ASSERT_FLOAT_WITHIN(provizio_test_entities_float_tolerance, provizio_test_entities_first_size_z,
+                             first_entity->size.z_meters);
+    TEST_ASSERT_EQUAL_UINT8(provizio_test_entities_first_entity_class, first_entity->entity_class);
+    TEST_ASSERT_EQUAL_UINT8(provizio_test_entities_first_entity_confidence, first_entity->entity_confidence);
+    TEST_ASSERT_EQUAL_UINT8(provizio_test_entities_first_entity_class_confidence,
+                            first_entity->entity_class_confidence);
 
     free(callback_data);
 }
@@ -764,7 +795,8 @@ static void test_receives_single_radar_entities_from_2_radars(void)
     send_test_callback_data.connection = &connection;
 
     status = send_test_entities(port_number, frame_index, timestamp, 0.0F, radar_position_ids, radar_ranges, num_radars,
-                                num_entities, &test_receive_entities_packet_on_packet_sent, &send_test_callback_data);
+                                num_entities, num_entities, &test_receive_entities_packet_on_packet_sent,
+                                &send_test_callback_data);
     TEST_ASSERT_EQUAL_INT32(0, status);
 
     status = provizio_close_radars_connection(&connection);
@@ -890,7 +922,7 @@ static void test_receive_radar_point_cloud_frame_position_ids_mismatch(void)
                                    &send_test_callback_data);
     TEST_ASSERT_EQUAL_INT32(0, status);
 
-    // Send the last missing point of the frame, but make sure it's ingored due to the radar position mismatch
+    // Send the last missing point of the frame, but make sure it's ignored due to the radar position mismatch
     status = send_test_point_cloud(port_number, frame_index, timestamp, x_offsets[1], &radar_position_ids[1], NULL, 1,
                                    num_points, 1, &test_receive_packet_on_packet_sent, &send_test_callback_data);
     TEST_ASSERT_EQUAL_INT32(PROVIZIO_E_SKIPPED, status);
@@ -2039,11 +2071,15 @@ static void test_duplicated_packets(void)
     const uint64_t timestamp = 0x0123456789abcdef;
     const uint16_t radar_position_id = provizio_radar_position_front_left;
     const uint16_t num_points = 5;
+    const uint16_t num_entities = 3;
 
     provizio_radar_point_cloud_api_context api_context;
     provizio_radar_point_cloud_api_context_init(NULL, NULL, &api_context);
+    provizio_radar_entities_api_context entities_api_context;
+    provizio_radar_entities_api_context_init(NULL, NULL, &entities_api_context);
     provizio_radar_api_connection connection;
-    int32_t status = provizio_open_radar_connection(port_number, 0, 0, &api_context, NULL, &connection);
+    int32_t status =
+        provizio_open_radar_connection(port_number, 0, 0, &api_context, &entities_api_context, &connection);
     TEST_ASSERT_EQUAL_INT32(0, status);
     TEST_ASSERT_TRUE(provizio_socket_valid(connection.sock)); // NOLINT: clang-tidy doesn't like TEST_ASSERT_TRUE
 
@@ -2052,6 +2088,14 @@ static void test_duplicated_packets(void)
     send_test_callback_data.contexts = &api_context;
     send_test_callback_data.num_contexts = 1;
     send_test_callback_data.connection = &connection;
+
+    test_receive_entities_packet_on_packet_sent_callback_data send_test_callback_entities_data;
+    memset(&send_test_callback_entities_data, 0, sizeof(send_test_callback_entities_data));
+    send_test_callback_entities_data.contexts = &entities_api_context;
+    send_test_callback_entities_data.num_contexts = 1;
+    send_test_callback_entities_data.connection = &connection;
+
+    // Point clouds
 
     // Send all but 1 last point
     status = send_test_point_cloud(port_number, frame_index, timestamp, 0, &radar_position_id, NULL, 1, num_points,
@@ -2075,6 +2119,35 @@ static void test_duplicated_packets(void)
     TEST_ASSERT_EQUAL_STRING("", provizio_test_error);
 #endif // PROVIZIO__AVOID_PACKETS_DUPLICATION
     TEST_ASSERT_EQUAL_UINT16(num_points - 1, api_context.impl.point_clouds_being_received[1].num_points_received);
+    provizio_set_on_error(NULL);
+
+    // Entities
+
+    // Send all but 1 last entity
+    status = send_test_entities(port_number, frame_index, timestamp, 0, &radar_position_id, NULL, 1, num_entities,
+                                num_entities - 1, &test_receive_entities_packet_on_packet_sent,
+                                &send_test_callback_entities_data);
+    TEST_ASSERT_EQUAL_INT32(0, status);
+
+    // Send it again
+    provizio_set_on_error(&test_provizio_on_error);
+    provizio_test_error[0] = '\0';
+    status = send_test_entities(port_number, frame_index, timestamp, 0, &radar_position_id, NULL, 1, num_entities,
+                                num_entities - 1, &test_receive_entities_packet_on_packet_sent,
+                                &send_test_callback_entities_data);
+#ifndef PROVIZIO__AVOID_PACKETS_DUPLICATION
+    // No duplications avoidance, i.e. it'll hit the "Too many entities received" issue
+    TEST_ASSERT_EQUAL_INT32(PROVIZIO_E_PROTOCOL, status);
+    TEST_ASSERT_EQUAL_STRING("provizio_check_for_too_many_entities: Too many entities received, consider enabling "
+                             "AVOID_PACKETS_DUPLICATION option",
+                             provizio_test_error);
+#else
+    // Duplications will be detected and dropped, and no error
+    TEST_ASSERT_EQUAL_INT32(PROVIZIO_E_SKIPPED, status);
+    TEST_ASSERT_EQUAL_STRING("", provizio_test_error);
+#endif // PROVIZIO__AVOID_PACKETS_DUPLICATION
+    TEST_ASSERT_EQUAL_UINT16(num_entities - 1,
+                             entities_api_context.impl.entities_frames_being_received[1].num_entities_received);
     provizio_set_on_error(NULL);
 
     status = provizio_close_radar_connection(&connection);

--- a/test/c_99/src/test_main.c
+++ b/test/c_99/src/test_main.c
@@ -27,10 +27,12 @@ void tearDown(void) // NOLINT: this exact name is required by the unit testing f
 int provizio_run_test_common(void);
 int provizio_run_test_util(void);
 int provizio_run_test_radar_point_cloud(void);
+int provizio_run_test_radar_entities(void);
 int provizio_run_test_core(void);
 int provizio_run_test_radar_points_accumulation_types(void);
 int provizio_run_test_radar_points_accumulation_filters(void);
 int provizio_run_test_points_accumulation(void);
+int provizio_run_test_quaternion(void);
 
 int main(int argc, char *argv[])
 {
@@ -42,10 +44,12 @@ int main(int argc, char *argv[])
     PROVIZIO__RUN_TEST(provizio_run_test_common);
     PROVIZIO__RUN_TEST(provizio_run_test_util);
     PROVIZIO__RUN_TEST(provizio_run_test_radar_point_cloud);
+    PROVIZIO__RUN_TEST(provizio_run_test_radar_entities);
     PROVIZIO__RUN_TEST(provizio_run_test_core);
     PROVIZIO__RUN_TEST(provizio_run_test_radar_points_accumulation_types);
     PROVIZIO__RUN_TEST(provizio_run_test_radar_points_accumulation_filters);
     PROVIZIO__RUN_TEST(provizio_run_test_points_accumulation);
+    PROVIZIO__RUN_TEST(provizio_run_test_quaternion);
 #undef PROVIZIO__RUN_TEST
 
     return result;

--- a/test/c_99/src/test_quaternion.c
+++ b/test/c_99/src/test_quaternion.c
@@ -1,0 +1,119 @@
+// Copyright 2025 Provizio Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "provizio/quaternion.h"
+
+#include "unity/unity.h"
+
+#include <linmath.h>
+#include <math.h>
+
+void test_provizio_quaternion_set_identity(void)
+{
+    provizio_quaternion quaternion = {2.0F, 3.0F, 4.0F, 5.0F}; // NOLINT Some "garbage" to make sure it gets overwritten
+    provizio_quaternion_set_identity(&quaternion);
+
+    TEST_ASSERT_EQUAL_FLOAT(1.0F, quaternion.w); // NOLINT
+    TEST_ASSERT_EQUAL_FLOAT(0.0F, quaternion.x); // NOLINT
+    TEST_ASSERT_EQUAL_FLOAT(0.0F, quaternion.y); // NOLINT
+    TEST_ASSERT_EQUAL_FLOAT(0.0F, quaternion.z); // NOLINT
+
+    vec3 in_vec = {10.0F, 100.0F, 1000.0F}; // NOLINT
+    quat in_quat = {quaternion.x, quaternion.y, quaternion.z, quaternion.w};
+    vec3 out_vec = {0, 0, 0};
+    quat_mul_vec3(out_vec, in_quat, in_vec);
+    TEST_ASSERT_EQUAL_FLOAT(in_vec[0], out_vec[0]); // NOLINT
+    TEST_ASSERT_EQUAL_FLOAT(in_vec[1], out_vec[1]); // NOLINT
+    TEST_ASSERT_EQUAL_FLOAT(in_vec[2], out_vec[2]); // NOLINT
+}
+
+void test_provizio_quaternion_set_euler_angles(void)
+{
+    provizio_quaternion quaternion = {2.0F, 3.0F, 4.0F, 5.0F}; // NOLINT Some "garbage" to make sure it gets overwritten
+
+    vec3 in_vec = {5.0F, 10.0F, 30.0F}; // NOLINT
+
+    // Rotate around X
+    {
+        provizio_quaternion_set_euler_angles((float)M_PI_2, 0.0F, 0.0F, &quaternion);
+        quat in_quat = {quaternion.x, quaternion.y, quaternion.z, quaternion.w};
+        vec3 out_vec = {0, 0, 0};
+        quat_mul_vec3(out_vec, in_quat, in_vec);
+        TEST_ASSERT_EQUAL_FLOAT(5.0F, out_vec[0]);   // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(-30.0F, out_vec[1]); // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(10.0F, out_vec[2]);  // NOLINT
+    }
+
+    // Rotate around Y
+    {
+        provizio_quaternion_set_euler_angles(0.0F, (float)M_PI_2, 0.0F, &quaternion);
+        quat in_quat = {quaternion.x, quaternion.y, quaternion.z, quaternion.w};
+        vec3 out_vec = {0, 0, 0};
+        quat_mul_vec3(out_vec, in_quat, in_vec);
+        TEST_ASSERT_EQUAL_FLOAT(30.0F, out_vec[0]); // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(10.0F, out_vec[1]); // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(-5.0F, out_vec[2]); // NOLINT
+    }
+
+    // Rotate around Z
+    {
+        provizio_quaternion_set_euler_angles(0.0F, 0.0F, (float)M_PI_2, &quaternion);
+        quat in_quat = {quaternion.x, quaternion.y, quaternion.z, quaternion.w};
+        vec3 out_vec = {0, 0, 0};
+        quat_mul_vec3(out_vec, in_quat, in_vec);
+        TEST_ASSERT_EQUAL_FLOAT(-10.0F, out_vec[0]); // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(5.0F, out_vec[1]);   // NOLINT
+        TEST_ASSERT_EQUAL_FLOAT(30.0F, out_vec[2]);  // NOLINT
+    }
+}
+
+void test_provizio_quaternion_is_valid_rotation(void)
+{
+    // Invalid: zero
+    {
+        const provizio_quaternion quaternion = {0, 0, 0, 0};
+        TEST_ASSERT_EQUAL(0, provizio_quaternion_is_valid_rotation(&quaternion));
+    }
+
+    // Invalid: garbage
+    {
+        const provizio_quaternion quaternion = {2.0F, 3.0F, 4.0F, 5.0F};
+        TEST_ASSERT_EQUAL(0, provizio_quaternion_is_valid_rotation(&quaternion));
+    }
+
+    // Valid: Identity
+    {
+        provizio_quaternion quaternion = {2.0F, 3.0F, 4.0F, 5.0F}; // NOLINT
+        provizio_quaternion_set_identity(&quaternion);
+        TEST_ASSERT_NOT_EQUAL(0, provizio_quaternion_is_valid_rotation(&quaternion));
+    }
+
+    // Valid: Rotation
+    {
+        provizio_quaternion quaternion = {2.0F, 3.0F, 4.0F, 5.0F}; // NOLINT
+        provizio_quaternion_set_euler_angles((float)M_PI_2, (float)M_PI_4, (float)M_E, &quaternion);
+        TEST_ASSERT_NOT_EQUAL(0, provizio_quaternion_is_valid_rotation(&quaternion));
+    }
+}
+
+int provizio_run_test_quaternion(void)
+{
+    UNITY_BEGIN();
+
+    RUN_TEST(test_provizio_quaternion_set_identity);
+    RUN_TEST(test_provizio_quaternion_set_euler_angles);
+    RUN_TEST(test_provizio_quaternion_is_valid_rotation);
+
+    return UNITY_END();
+}

--- a/test/c_99/src/test_radar_entities.c
+++ b/test/c_99/src/test_radar_entities.c
@@ -209,6 +209,8 @@ static void test_provizio_handle_entities_packet_warnings(void)
 
     provizio_set_on_warning(&test_provizio_on_warning);
 
+    packet.radar_entities[0].x_meters +=
+        provizio_test_entities_offset_step; // So the packet is not detected as duplicated
     provizio_set_protocol_field_uint16_t(&packet.header.total_entities_in_frame, num_entities + 1);
     TEST_ASSERT_EQUAL_INT32(
         0, provizio_handle_entities_packet(&api_context, &packet, provizio_radar_entities_packet_size(&packet.header)));
@@ -217,6 +219,8 @@ static void test_provizio_handle_entities_packet_warnings(void)
                              provizio_test_warning);
     provizio_set_protocol_field_uint16_t(&packet.header.total_entities_in_frame, num_entities);
 
+    packet.radar_entities[0].x_meters +=
+        provizio_test_entities_offset_step; // So the packet is not detected as duplicated
     provizio_set_protocol_field_uint16_t(&packet.header.radar_range, provizio_radar_range_medium);
     TEST_ASSERT_EQUAL_INT32(
         0, provizio_handle_entities_packet(&api_context, &packet, provizio_radar_entities_packet_size(&packet.header)));
@@ -613,7 +617,12 @@ static void test_provizio_handle_entities_packet_too_many_entities(void)
     TEST_ASSERT_EQUAL_INT32(
         PROVIZIO_E_PROTOCOL,
         provizio_handle_entities_packet(&api_context, &packet, provizio_radar_entities_packet_size(&packet.header)));
-    TEST_ASSERT_EQUAL_STRING("provizio_check_for_too_many_entities: Too many entities received", provizio_test_error);
+    const char *expected_message = "provizio_check_for_too_many_entities: Too many entities received"
+#ifndef PROVIZIO__AVOID_PACKETS_DUPLICATION
+                                   ", consider enabling AVOID_PACKETS_DUPLICATION option"
+#endif
+        ;
+    TEST_ASSERT_EQUAL_STRING(expected_message, provizio_test_error);
     provizio_set_on_error(NULL);
 }
 

--- a/test/c_99/src/test_radar_entities.c
+++ b/test/c_99/src/test_radar_entities.c
@@ -1,0 +1,647 @@
+// Copyright 2025 Provizio Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "unity/unity.h"
+
+#include "provizio/radar_api/entities.h"
+#include "provizio/radar_api/errno.h"
+#include "provizio/util.h"
+
+#include "test_entities_callbacks.h"
+#include "test_entities_helpers.h"
+
+enum
+{
+    test_message_length = 1024
+};
+static char provizio_test_warning[test_message_length]; // NOLINT: non-const global by design
+static char provizio_test_error[test_message_length];   // NOLINT: non-const global by design
+
+static const float provizio_test_entities_offset_step = 1.0F;
+static const float provizio_test_entities_reset_offset_multiplier = 2.0F;
+static const float provizio_test_entities_helper_min_value = 5.0F;
+static const float provizio_test_entities_helper_inverted_min_value = 10.0F;
+static const float provizio_test_entities_zero = 0.0F;
+static const float provizio_test_entities_helper_tolerance = 0.0001F;
+
+static void test_provizio_on_warning(const char *warning)
+{
+    strncpy(provizio_test_warning, warning, test_message_length - 1);
+}
+
+static void test_provizio_on_error(const char *error)
+{
+    strncpy(provizio_test_error, error, test_message_length - 1);
+}
+
+void test_provizio_radar_entities_callback(const provizio_radar_entities_frame *entities_frame,
+                                           provizio_radar_entities_api_context *context)
+{
+    test_provizio_radar_entities_callback_data *data = (test_provizio_radar_entities_callback_data *)context->user_data;
+
+    ++data->called_times;
+
+    memmove(&data->last_entities_frames[1], &data->last_entities_frames[0],
+            sizeof(provizio_radar_entities_frame) * (PROVIZIO__TEST_CALLBACK_DATA_NUM_ENTITIES_FRAMES - 1));
+
+    data->last_entities_frames[0] = *entities_frame;
+}
+
+static void test_provizio_radar_entities_packet_size(void)
+{
+    provizio_radar_entities_packet_header header;
+    memset(&header, 0, sizeof(header));
+
+    provizio_set_protocol_field_uint16_t(&header.num_entities_in_packet, 0);
+    TEST_ASSERT_EQUAL_UINT64(sizeof(header), provizio_radar_entities_packet_size(&header));
+
+    provizio_set_protocol_field_uint16_t(&header.num_entities_in_packet, 1);
+    TEST_ASSERT_EQUAL_UINT64(sizeof(header) + sizeof(provizio_radar_entity),
+                             provizio_radar_entities_packet_size(&header));
+
+    provizio_set_protocol_field_uint16_t(&header.num_entities_in_packet, 2);
+    TEST_ASSERT_EQUAL_UINT64(sizeof(header) + sizeof(provizio_radar_entity) * 2, // NOLINT
+                             provizio_radar_entities_packet_size(&header));
+
+    provizio_set_protocol_field_uint16_t(&header.num_entities_in_packet, PROVIZIO__MAX_RADAR_ENTITIES_PER_UDP_PACKET);
+    TEST_ASSERT_EQUAL_UINT64(sizeof(header) +
+                                 (sizeof(provizio_radar_entity) * PROVIZIO__MAX_RADAR_ENTITIES_PER_UDP_PACKET),
+                             provizio_radar_entities_packet_size(&header));
+
+    provizio_set_on_warning(&test_provizio_on_warning);
+    provizio_set_protocol_field_uint16_t(&header.num_entities_in_packet,
+                                         PROVIZIO__MAX_RADAR_ENTITIES_PER_UDP_PACKET + 1);
+    TEST_ASSERT_EQUAL_UINT64(0, provizio_radar_entities_packet_size(&header));
+    TEST_ASSERT_EQUAL_STRING("provizio_radar_entities_packet_size: num_entities_in_packet exceeds "
+                             "PROVIZIO__MAX_RADAR_ENTITIES_PER_UDP_PACKET!",
+                             provizio_test_warning);
+    provizio_set_on_warning(NULL);
+}
+
+static void test_provizio_check_radar_entities_packet(void)
+{
+    const uint16_t num_entities = 8;
+
+    provizio_set_on_error(&test_provizio_on_error);
+
+    test_provizio_radar_entities_callback_data *callback_data =
+        (test_provizio_radar_entities_callback_data *)malloc(sizeof(test_provizio_radar_entities_callback_data));
+    memset(callback_data, 0, sizeof(test_provizio_radar_entities_callback_data));
+
+    provizio_radar_entities_api_context api_context;
+    provizio_radar_entities_api_context_init(&test_provizio_radar_entities_callback, callback_data, &api_context);
+    TEST_ASSERT_NOT_EQUAL(NULL, api_context.callback);
+
+    provizio_radar_entities_packet packet;
+    memset(&packet, 0, sizeof(packet));
+
+    TEST_ASSERT_EQUAL_INT32(
+        PROVIZIO_E_PROTOCOL,
+        provizio_handle_entities_packet(&api_context, &packet, sizeof(provizio_radar_api_protocol_header) - 1));
+    TEST_ASSERT_EQUAL_STRING("provizio_check_radar_entities_packet: insufficient packet_size", provizio_test_error);
+
+    provizio_set_protocol_field_uint16_t(&packet.header.protocol_header.packet_type,
+                                         PROVIZIO__RADAR_API_ENTITIES_PACKET_TYPE + 1);
+    TEST_ASSERT_EQUAL_INT32(PROVIZIO_E_PROTOCOL,
+                            provizio_handle_entities_packet(&api_context, &packet, sizeof(packet)));
+    TEST_ASSERT_EQUAL_STRING("provizio_check_radar_entities_packet: unexpected packet_type", provizio_test_error);
+    provizio_set_protocol_field_uint16_t(&packet.header.protocol_header.packet_type,
+                                         PROVIZIO__RADAR_API_ENTITIES_PACKET_TYPE);
+
+    provizio_set_protocol_field_uint16_t(&packet.header.protocol_header.protocol_version,
+                                         PROVIZIO__RADAR_API_ENTITY_PROTOCOL_VERSION + 1);
+    TEST_ASSERT_EQUAL_INT32(PROVIZIO_E_PROTOCOL,
+                            provizio_handle_entities_packet(&api_context, &packet, sizeof(packet)));
+    TEST_ASSERT_EQUAL_STRING("provizio_check_radar_entities_packet: Incompatible protocol version",
+                             provizio_test_error);
+    provizio_set_protocol_field_uint16_t(&packet.header.protocol_header.protocol_version,
+                                         PROVIZIO__RADAR_API_ENTITY_PROTOCOL_VERSION);
+
+    TEST_ASSERT_EQUAL_INT32(
+        PROVIZIO_E_PROTOCOL,
+        provizio_handle_entities_packet(&api_context, &packet, sizeof(provizio_radar_entities_packet_header) - 1));
+    TEST_ASSERT_EQUAL_STRING("provizio_check_radar_entities_packet: insufficient packet_size", provizio_test_error);
+
+    provizio_set_protocol_field_uint16_t(&packet.header.num_entities_in_packet,
+                                         PROVIZIO__MAX_RADAR_ENTITIES_PER_UDP_PACKET + 1);
+    TEST_ASSERT_EQUAL_INT32(PROVIZIO_E_PROTOCOL,
+                            provizio_handle_entities_packet(&api_context, &packet, sizeof(packet)));
+    TEST_ASSERT_EQUAL_STRING("provizio_check_radar_entities_packet: incorrect num_entities_in_packet",
+                             provizio_test_error);
+    provizio_set_protocol_field_uint16_t(&packet.header.num_entities_in_packet, num_entities);
+
+    TEST_ASSERT_EQUAL_INT32(PROVIZIO_E_PROTOCOL,
+                            provizio_handle_entities_packet(&api_context, &packet,
+                                                            provizio_radar_entities_packet_size(&packet.header) - 1));
+    TEST_ASSERT_EQUAL_STRING("provizio_check_radar_entities_packet: incorrect packet_size", provizio_test_error);
+    TEST_ASSERT_EQUAL_INT32(PROVIZIO_E_PROTOCOL,
+                            provizio_handle_entities_packet(&api_context, &packet,
+                                                            provizio_radar_entities_packet_size(&packet.header) + 1));
+    TEST_ASSERT_EQUAL_STRING("provizio_check_radar_entities_packet: incorrect packet_size", provizio_test_error);
+
+    provizio_set_protocol_field_uint16_t(&packet.header.radar_position_id, provizio_radar_position_unknown);
+    TEST_ASSERT_EQUAL_INT32(
+        PROVIZIO_E_PROTOCOL,
+        provizio_handle_entities_packet(&api_context, &packet, provizio_radar_entities_packet_size(&packet.header)));
+    TEST_ASSERT_EQUAL_STRING("provizio_check_radar_entities_packet: the value of radar_position_id can't be "
+                             "provizio_radar_position_unknown",
+                             provizio_test_error);
+    provizio_set_protocol_field_uint16_t(&packet.header.radar_position_id, provizio_radar_position_front_center);
+
+    provizio_set_protocol_field_uint16_t(&packet.header.total_entities_in_frame,
+                                         PROVIZIO__MAX_RADAR_ENTITIES_PER_FRAME + 1);
+    TEST_ASSERT_EQUAL_INT32(
+        PROVIZIO_E_PROTOCOL,
+        provizio_handle_entities_packet(&api_context, &packet, provizio_radar_entities_packet_size(&packet.header)));
+    TEST_ASSERT_EQUAL_STRING("provizio_check_radar_entities_packet: total_entities_in_frame exceeds "
+                             "PROVIZIO__MAX_RADAR_ENTITIES_PER_FRAME",
+                             provizio_test_error);
+    provizio_set_protocol_field_uint16_t(&packet.header.total_entities_in_frame, num_entities);
+
+    provizio_set_protocol_field_uint16_t(&packet.header.num_entities_in_packet, num_entities + 1);
+    TEST_ASSERT_EQUAL_INT32(
+        PROVIZIO_E_PROTOCOL,
+        provizio_handle_entities_packet(&api_context, &packet, provizio_radar_entities_packet_size(&packet.header)));
+    TEST_ASSERT_EQUAL_STRING("provizio_check_radar_entities_packet: num_entities_in_packet exceeds "
+                             "total_entities_in_frame",
+                             provizio_test_error);
+    provizio_set_protocol_field_uint16_t(&packet.header.num_entities_in_packet, num_entities);
+
+    free(callback_data);
+    provizio_set_on_error(NULL);
+}
+
+static void test_provizio_handle_entities_packet_warnings(void)
+{
+    const uint32_t frame_index = 1;
+    const uint64_t timestamp = 2;
+    const uint16_t radar_position_id = provizio_radar_position_front_center;
+    const uint16_t radar_range = provizio_radar_range_long;
+    const uint16_t num_entities = 4;
+
+    provizio_radar_entities_api_context api_context;
+    test_provizio_radar_entities_callback_data *callback_data =
+        (test_provizio_radar_entities_callback_data *)malloc(sizeof(test_provizio_radar_entities_callback_data));
+    memset(callback_data, 0, sizeof(test_provizio_radar_entities_callback_data));
+    provizio_radar_entities_api_context_init(&test_provizio_radar_entities_callback, callback_data, &api_context);
+
+    provizio_radar_entities_packet packet;
+    TEST_ASSERT_EQUAL_INT32(0, provizio_test_create_entities_packet(&packet, frame_index, timestamp, radar_position_id,
+                                                                    radar_range, num_entities, 1, 0.0F));
+
+    TEST_ASSERT_EQUAL_INT32(
+        0, provizio_handle_entities_packet(&api_context, &packet, provizio_radar_entities_packet_size(&packet.header)));
+
+    provizio_set_on_warning(&test_provizio_on_warning);
+
+    provizio_set_protocol_field_uint16_t(&packet.header.total_entities_in_frame, num_entities + 1);
+    TEST_ASSERT_EQUAL_INT32(
+        0, provizio_handle_entities_packet(&api_context, &packet, provizio_radar_entities_packet_size(&packet.header)));
+    TEST_ASSERT_EQUAL_STRING("provizio_get_entities_frame_being_received: num_entities_expected mismatch across "
+                             "different packets of the same frame",
+                             provizio_test_warning);
+    provizio_set_protocol_field_uint16_t(&packet.header.total_entities_in_frame, num_entities);
+
+    provizio_set_protocol_field_uint16_t(&packet.header.radar_range, provizio_radar_range_medium);
+    TEST_ASSERT_EQUAL_INT32(
+        0, provizio_handle_entities_packet(&api_context, &packet, provizio_radar_entities_packet_size(&packet.header)));
+    TEST_ASSERT_EQUAL_STRING("provizio_get_entities_frame_being_received: radar_range mismatch across different "
+                             "packets of the same frame",
+                             provizio_test_warning);
+
+    provizio_set_on_warning(NULL);
+    free(callback_data);
+}
+
+static void test_provizio_return_entities_frame_returns_older_first(void)
+{
+    const uint32_t frame_indices[2] = {10U, 11U};
+    const uint16_t radar_position_id = provizio_radar_position_front_left;
+    const uint16_t total_entities_in_first_frame = 3;
+    const uint16_t total_entities_in_second_frame = 1;
+
+    test_provizio_radar_entities_callback_data *callback_data =
+        (test_provizio_radar_entities_callback_data *)malloc(sizeof(test_provizio_radar_entities_callback_data));
+    TEST_ASSERT_NOT_EQUAL(NULL, callback_data);
+    memset(callback_data, 0, sizeof(test_provizio_radar_entities_callback_data));
+
+    provizio_radar_entities_api_context api_context;
+    provizio_radar_entities_api_context_init(&test_provizio_radar_entities_callback, callback_data, &api_context);
+
+    provizio_radar_entities_packet packet;
+    TEST_ASSERT_EQUAL_INT32(0, provizio_test_create_entities_packet(
+                                   &packet, frame_indices[0], 100U, radar_position_id, provizio_radar_range_short,
+                                   total_entities_in_first_frame, total_entities_in_first_frame - 1, 0.0F));
+    TEST_ASSERT_EQUAL_INT32(
+        0, provizio_handle_entities_packet(&api_context, &packet, provizio_radar_entities_packet_size(&packet.header)));
+    TEST_ASSERT_EQUAL_INT32(0, callback_data->called_times);
+
+    TEST_ASSERT_EQUAL_INT32(
+        0, provizio_test_create_entities_packet(&packet, frame_indices[1], 200U, radar_position_id,
+                                                provizio_radar_range_short, total_entities_in_second_frame,
+                                                total_entities_in_second_frame, provizio_test_entities_offset_step));
+    TEST_ASSERT_EQUAL_INT32(
+        0, provizio_handle_entities_packet(&api_context, &packet, provizio_radar_entities_packet_size(&packet.header)));
+
+    TEST_ASSERT_EQUAL_INT32(2, callback_data->called_times);
+    TEST_ASSERT_EQUAL_UINT32(frame_indices[0], callback_data->last_entities_frames[1].frame_index);
+    TEST_ASSERT_EQUAL_UINT32(frame_indices[1], callback_data->last_entities_frames[0].frame_index);
+
+    free(callback_data);
+}
+
+static void test_provizio_handle_entities_packet_empty_frame(void)
+{
+    const uint32_t frame_index = 42U;
+    const uint64_t timestamp = 200U;
+    const uint16_t radar_position_id = provizio_radar_position_rear_right;
+
+    test_provizio_radar_entities_callback_data *callback_data =
+        (test_provizio_radar_entities_callback_data *)malloc(sizeof(test_provizio_radar_entities_callback_data));
+    TEST_ASSERT_NOT_EQUAL(NULL, callback_data);
+    memset(callback_data, 0, sizeof(test_provizio_radar_entities_callback_data));
+
+    provizio_radar_entities_api_context api_context;
+    provizio_radar_entities_api_context_init(&test_provizio_radar_entities_callback, callback_data, &api_context);
+
+    provizio_radar_entities_packet packet;
+    TEST_ASSERT_EQUAL_INT32(0, provizio_test_create_entities_packet(&packet, frame_index, timestamp, radar_position_id,
+                                                                    provizio_radar_range_medium, 0, 0, 0.0F));
+
+    TEST_ASSERT_EQUAL_INT32(
+        PROVIZIO_E_SKIPPED,
+        provizio_handle_entities_packet(&api_context, &packet, provizio_radar_entities_packet_size(&packet.header)));
+    TEST_ASSERT_EQUAL_INT32(0, callback_data->called_times);
+
+    free(callback_data);
+}
+
+static void test_provizio_handle_radars_entities_packet_reuses_existing_context(void)
+{
+    const uint16_t radar_position_id = provizio_radar_position_front_right;
+    const size_t num_contexts = 2;
+
+    test_provizio_radar_entities_callback_data *callback_data =
+        (test_provizio_radar_entities_callback_data *)malloc(sizeof(test_provizio_radar_entities_callback_data));
+    TEST_ASSERT_NOT_EQUAL(NULL, callback_data);
+    memset(callback_data, 0, sizeof(test_provizio_radar_entities_callback_data));
+
+    provizio_radar_entities_api_context *contexts = (provizio_radar_entities_api_context *)malloc(
+        sizeof(provizio_radar_entities_api_context) * num_contexts); // NOLINT: intentional heap allocation
+    TEST_ASSERT_NOT_EQUAL(NULL, contexts);
+    provizio_radar_entities_api_contexts_init(&test_provizio_radar_entities_callback, callback_data, contexts,
+                                              num_contexts);
+
+    TEST_ASSERT_EQUAL_INT32(0, provizio_radar_entities_api_context_assign(&contexts[0], radar_position_id));
+
+    provizio_radar_entities_packet packet;
+    TEST_ASSERT_EQUAL_INT32(0, provizio_test_create_entities_packet(&packet, 5U, 6U, radar_position_id,
+                                                                    provizio_radar_range_short, 1, 1, 0.0F));
+
+    TEST_ASSERT_EQUAL_INT32(
+        0, provizio_handle_radars_entities_packet(contexts, num_contexts, &packet,
+                                                  provizio_radar_entities_packet_size(&packet.header)));
+    TEST_ASSERT_EQUAL_INT32(1, callback_data->called_times);
+    TEST_ASSERT_EQUAL_UINT16(radar_position_id, callback_data->last_entities_frames[0].radar_position_id);
+
+    free(contexts);
+    free(callback_data);
+}
+
+static void test_provizio_handle_radars_entities_packet_out_of_contexts(void)
+{
+    const uint16_t radar_position_id = provizio_radar_position_front_left;
+    const uint16_t unexpected_radar_position_id = provizio_radar_position_rear_left;
+    const size_t num_contexts = 1;
+
+    test_provizio_radar_entities_callback_data *callback_data =
+        (test_provizio_radar_entities_callback_data *)malloc(sizeof(test_provizio_radar_entities_callback_data));
+    TEST_ASSERT_NOT_EQUAL(NULL, callback_data);
+    memset(callback_data, 0, sizeof(test_provizio_radar_entities_callback_data));
+
+    provizio_radar_entities_api_context *contexts = (provizio_radar_entities_api_context *)malloc(
+        sizeof(provizio_radar_entities_api_context) * num_contexts); // NOLINT: intentional heap allocation
+    TEST_ASSERT_NOT_EQUAL(NULL, contexts);
+    provizio_radar_entities_api_contexts_init(&test_provizio_radar_entities_callback, callback_data, contexts,
+                                              num_contexts);
+
+    TEST_ASSERT_EQUAL_INT32(0, provizio_radar_entities_api_context_assign(&contexts[0], radar_position_id));
+
+    provizio_radar_entities_packet packet;
+    TEST_ASSERT_EQUAL_INT32(0, provizio_test_create_entities_packet(&packet, 100U, 200U, unexpected_radar_position_id,
+                                                                    provizio_radar_range_medium, 1, 1, 0.0F));
+
+    provizio_set_on_error(&test_provizio_on_error);
+    TEST_ASSERT_EQUAL_INT32(PROVIZIO_E_OUT_OF_CONTEXTS,
+                            provizio_handle_radars_entities_packet(
+                                contexts, num_contexts, &packet, provizio_radar_entities_packet_size(&packet.header)));
+    TEST_ASSERT_EQUAL_STRING("provizio_get_radar_entities_api_context_by_position_id: Out of available contexts",
+                             provizio_test_error);
+    provizio_set_on_error(NULL);
+
+    free(contexts);
+    free(callback_data);
+}
+
+static void test_provizio_test_next_value_handles_nonpositive_range(void)
+{
+    TEST_ASSERT_FLOAT_WITHIN(
+        provizio_test_entities_helper_tolerance, provizio_test_entities_helper_min_value,
+        provizio_test_next_value(provizio_test_entities_offset_step, provizio_test_entities_helper_min_value,
+                                 provizio_test_entities_helper_min_value, provizio_test_entities_offset_step));
+
+    TEST_ASSERT_FLOAT_WITHIN(
+        provizio_test_entities_helper_tolerance, provizio_test_entities_helper_inverted_min_value,
+        provizio_test_next_value(provizio_test_entities_zero, provizio_test_entities_helper_inverted_min_value,
+                                 provizio_test_entities_helper_min_value, provizio_test_entities_offset_step));
+}
+
+static void test_provizio_radar_entities_api_context_assign(void)
+{
+    const uint32_t frame_index = 5;
+    const uint64_t timestamp = 10;
+    const uint16_t radar_position_id = provizio_radar_position_front_left;
+    const uint16_t num_entities = 3;
+
+    provizio_radar_entities_api_context api_context;
+    provizio_radar_entities_api_context_init(NULL, NULL, &api_context);
+
+    TEST_ASSERT_EQUAL_INT32(0, provizio_radar_entities_api_context_assign(&api_context, radar_position_id));
+
+    provizio_radar_entities_packet packet;
+    TEST_ASSERT_EQUAL_INT32(0, provizio_test_create_entities_packet(&packet, frame_index, timestamp, radar_position_id,
+                                                                    provizio_radar_range_medium, num_entities,
+                                                                    num_entities - 1, 0.0F));
+
+    TEST_ASSERT_EQUAL_INT32(
+        0, provizio_handle_entities_packet(&api_context, &packet, provizio_radar_entities_packet_size(&packet.header)));
+
+    provizio_set_protocol_field_uint16_t(&packet.header.radar_position_id, radar_position_id + 1);
+    TEST_ASSERT_EQUAL_INT32(
+        PROVIZIO_E_SKIPPED,
+        provizio_handle_entities_packet(&api_context, &packet, provizio_radar_entities_packet_size(&packet.header)));
+
+    TEST_ASSERT_EQUAL_INT32(0, provizio_radar_entities_api_context_assign(&api_context, radar_position_id));
+
+    provizio_set_on_error(&test_provizio_on_error);
+    TEST_ASSERT_EQUAL_INT32(PROVIZIO_E_NOT_SUPPORTED,
+                            provizio_radar_entities_api_context_assign(&api_context, radar_position_id + 1));
+    TEST_ASSERT_EQUAL_STRING("provizio_radar_entities_api_context_assign: already assigned", provizio_test_error);
+
+    TEST_ASSERT_EQUAL_INT32(PROVIZIO_E_ARGUMENT,
+                            provizio_radar_entities_api_context_assign(&api_context, provizio_radar_position_unknown));
+    TEST_ASSERT_EQUAL_STRING(
+        "provizio_radar_entities_api_context_assign: can't assign to provizio_radar_position_unknown",
+        provizio_test_error);
+    provizio_set_on_error(NULL);
+}
+
+static void test_provizio_handle_radars_entities_packet_bad_packet(void)
+{
+    provizio_radar_entities_packet bad_packet;
+    memset(&bad_packet, 0, sizeof(bad_packet));
+
+    provizio_set_on_error(&test_provizio_on_error);
+    TEST_ASSERT_EQUAL_INT32(
+        PROVIZIO_E_PROTOCOL,
+        provizio_handle_radars_entities_packet(NULL, 0, &bad_packet, sizeof(bad_packet.header.protocol_header) - 1));
+    TEST_ASSERT_EQUAL_STRING("provizio_check_radar_entities_packet: insufficient packet_size", provizio_test_error);
+    provizio_set_on_error(NULL);
+}
+
+static void test_provizio_handle_possible_radar_entities_packet_wrong_packet_size(void)
+{
+    provizio_radar_entities_packet bad_packet;
+    memset(&bad_packet, 0, sizeof(bad_packet));
+
+    TEST_ASSERT_EQUAL_INT32(PROVIZIO_E_SKIPPED,
+                            provizio_handle_possible_radar_entities_packet(
+                                NULL, &bad_packet, sizeof(provizio_radar_entities_packet_header) - 1));
+}
+
+static void test_provizio_handle_possible_radar_entities_packet_wrong_packet_type(void)
+{
+    provizio_radar_entities_packet bad_packet;
+    memset(&bad_packet, 0, sizeof(bad_packet));
+
+    provizio_set_protocol_field_uint16_t(&bad_packet.header.protocol_header.packet_type,
+                                         PROVIZIO__RADAR_API_ENTITIES_PACKET_TYPE + 1);
+    TEST_ASSERT_EQUAL_INT32(PROVIZIO_E_SKIPPED, provizio_handle_possible_radar_entities_packet(
+                                                    NULL, &bad_packet, sizeof(bad_packet.header)));
+}
+
+static void test_provizio_handle_possible_radar_entities_packet_wrong_protocol_version(void)
+{
+    provizio_radar_entities_packet bad_packet;
+    memset(&bad_packet, 0, sizeof(bad_packet));
+
+    provizio_set_protocol_field_uint16_t(&bad_packet.header.protocol_header.packet_type,
+                                         PROVIZIO__RADAR_API_ENTITIES_PACKET_TYPE);
+    provizio_set_protocol_field_uint16_t(&bad_packet.header.protocol_header.protocol_version,
+                                         PROVIZIO__RADAR_API_ENTITY_PROTOCOL_VERSION + 1);
+
+    TEST_ASSERT_EQUAL_INT32(PROVIZIO_E_PROTOCOL, provizio_handle_possible_radar_entities_packet(
+                                                     NULL, &bad_packet, sizeof(bad_packet.header)));
+}
+
+static void test_provizio_handle_possible_radar_entities_packet_ok(void)
+{
+    const uint16_t num_entities = 6;
+
+    test_provizio_radar_entities_callback_data *callback_data =
+        (test_provizio_radar_entities_callback_data *)malloc(sizeof(test_provizio_radar_entities_callback_data));
+    memset(callback_data, 0, sizeof(test_provizio_radar_entities_callback_data));
+
+    provizio_radar_entities_api_context api_context;
+    provizio_radar_entities_api_context_init(&test_provizio_radar_entities_callback, callback_data, &api_context);
+
+    provizio_radar_entities_packet packet;
+    TEST_ASSERT_EQUAL_INT32(0, provizio_test_create_entities_packet(&packet, 10, 20, provizio_radar_position_rear_left,
+                                                                    provizio_radar_range_long, num_entities,
+                                                                    num_entities, 0.0F));
+
+    TEST_ASSERT_EQUAL_INT32(0, provizio_handle_possible_radar_entities_packet(
+                                   &api_context, &packet, provizio_radar_entities_packet_size(&packet.header)));
+
+    free(callback_data);
+}
+
+static void test_provizio_handle_possible_radars_entities_packet_ok(void)
+{
+    const uint16_t radar_position_ids[2] = {provizio_radar_position_rear_left, provizio_radar_position_rear_right};
+    const uint16_t num_entities = 5;
+    const size_t num_contexts = sizeof(radar_position_ids) / sizeof(radar_position_ids[0]);
+
+    provizio_radar_entities_api_context *contexts =
+        (provizio_radar_entities_api_context *)malloc(sizeof(provizio_radar_entities_api_context) * num_contexts);
+    TEST_ASSERT_NOT_EQUAL(NULL, contexts);
+    test_provizio_radar_entities_callback_data *callback_data =
+        (test_provizio_radar_entities_callback_data *)malloc(sizeof(test_provizio_radar_entities_callback_data));
+    memset(callback_data, 0, sizeof(test_provizio_radar_entities_callback_data));
+    provizio_radar_entities_api_contexts_init(&test_provizio_radar_entities_callback, callback_data, contexts,
+                                              num_contexts);
+    TEST_ASSERT_NOT_EQUAL(NULL, contexts[0].callback);
+
+    for (size_t i = 0; i < num_contexts; ++i)
+    {
+        provizio_radar_entities_packet packet;
+        TEST_ASSERT_EQUAL_INT32(0, provizio_test_create_entities_packet(&packet, 10, 20, radar_position_ids[i],
+                                                                        provizio_radar_range_short, num_entities,
+                                                                        num_entities, (float)i));
+
+        TEST_ASSERT_EQUAL_INT32(
+            0, provizio_handle_possible_radars_entities_packet(contexts, num_contexts, &packet,
+                                                               provizio_radar_entities_packet_size(&packet.header)));
+    }
+
+    free(contexts);
+    free(callback_data);
+}
+
+static void test_provizio_handle_entities_packet_frame_indices_overflow(void)
+{
+    const uint16_t radar_position_id = provizio_radar_position_rear_left;
+    const uint32_t frame_indices[3] = {0xfffffffeU, 0xffffffffU, 0};
+    const uint16_t num_entities = 6;
+
+    test_provizio_radar_entities_callback_data *callback_data =
+        (test_provizio_radar_entities_callback_data *)malloc(sizeof(test_provizio_radar_entities_callback_data));
+    memset(callback_data, 0, sizeof(test_provizio_radar_entities_callback_data));
+
+    provizio_radar_entities_api_context api_context;
+    provizio_radar_entities_api_context_init(&test_provizio_radar_entities_callback, callback_data, &api_context);
+
+    provizio_radar_entities_packet packet;
+    TEST_ASSERT_EQUAL_INT32(0, provizio_test_create_entities_packet(&packet, frame_indices[0], 1, radar_position_id,
+                                                                    provizio_radar_range_medium, num_entities,
+                                                                    num_entities, 0.0F));
+    TEST_ASSERT_EQUAL_INT32(
+        0, provizio_handle_entities_packet(&api_context, &packet, provizio_radar_entities_packet_size(&packet.header)));
+
+    TEST_ASSERT_EQUAL_INT32(0, provizio_test_create_entities_packet(
+                                   &packet, frame_indices[1], 2, radar_position_id, provizio_radar_range_medium,
+                                   num_entities, num_entities - 1, provizio_test_entities_offset_step));
+    TEST_ASSERT_EQUAL_INT32(
+        0, provizio_handle_entities_packet(&api_context, &packet, provizio_radar_entities_packet_size(&packet.header)));
+
+    provizio_set_on_warning(&test_provizio_on_warning);
+    TEST_ASSERT_EQUAL_INT32(
+        0, provizio_test_create_entities_packet(
+               &packet, frame_indices[2], 3, radar_position_id, provizio_radar_range_medium, num_entities, num_entities,
+               provizio_test_entities_offset_step * provizio_test_entities_reset_offset_multiplier));
+    TEST_ASSERT_EQUAL_INT32(
+        0, provizio_handle_entities_packet(&api_context, &packet, provizio_radar_entities_packet_size(&packet.header)));
+    TEST_ASSERT_EQUAL_STRING(
+        "provizio_get_entities_frame_being_received: frame indices overflow detected - resetting API state",
+        provizio_test_warning);
+    provizio_set_on_warning(NULL);
+
+    TEST_ASSERT_EQUAL_INT32(2, callback_data->called_times);
+    TEST_ASSERT_EQUAL_UINT32(frame_indices[0], callback_data->last_entities_frames[1].frame_index);
+    TEST_ASSERT_EQUAL_UINT32(frame_indices[2], callback_data->last_entities_frames[0].frame_index);
+
+    free(callback_data);
+}
+
+static void test_provizio_handle_entities_packet_drop_obsolete_incomplete_frame(void)
+{
+    const uint16_t radar_position_id = provizio_radar_position_front_left;
+    const uint32_t frame_indices[3] = {17, 18, 19};
+    const uint16_t num_entities = 10;
+
+    test_provizio_radar_entities_callback_data *callback_data =
+        (test_provizio_radar_entities_callback_data *)malloc(sizeof(test_provizio_radar_entities_callback_data));
+    memset(callback_data, 0, sizeof(test_provizio_radar_entities_callback_data));
+
+    provizio_radar_entities_api_context api_context;
+    provizio_radar_entities_api_context_init(&test_provizio_radar_entities_callback, callback_data, &api_context);
+
+    provizio_radar_entities_packet packet;
+    for (size_t i = 0; i < sizeof(frame_indices) / sizeof(frame_indices[0]); ++i)
+    {
+        TEST_ASSERT_EQUAL_INT32(0, provizio_test_create_entities_packet(&packet, frame_indices[i], (uint64_t)i,
+                                                                        radar_position_id, provizio_radar_range_medium,
+                                                                        num_entities, num_entities - 1, (float)i));
+        TEST_ASSERT_EQUAL_INT32(0, provizio_handle_entities_packet(
+                                       &api_context, &packet, provizio_radar_entities_packet_size(&packet.header)));
+    }
+
+    TEST_ASSERT_EQUAL_INT32(1, callback_data->called_times);
+    TEST_ASSERT_EQUAL_UINT32(frame_indices[0], callback_data->last_entities_frames[0].frame_index);
+    TEST_ASSERT_EQUAL_UINT16(num_entities, callback_data->last_entities_frames[0].num_entities_expected);
+    TEST_ASSERT_EQUAL_UINT16(num_entities - 1, callback_data->last_entities_frames[0].num_entities_received);
+
+    free(callback_data);
+}
+
+static void test_provizio_handle_entities_packet_too_many_entities(void)
+{
+    const uint16_t radar_position_id = provizio_radar_position_front_center;
+    const uint16_t num_entities = 6;
+
+    provizio_radar_entities_api_context api_context;
+    provizio_radar_entities_api_context_init(NULL, NULL, &api_context);
+
+    provizio_radar_entities_packet packet;
+    TEST_ASSERT_EQUAL_INT32(0, provizio_test_create_entities_packet(&packet, 100, 200, radar_position_id,
+                                                                    provizio_radar_range_short, num_entities,
+                                                                    num_entities - 1, 0.0F));
+    TEST_ASSERT_EQUAL_INT32(
+        0, provizio_handle_entities_packet(&api_context, &packet, provizio_radar_entities_packet_size(&packet.header)));
+
+    TEST_ASSERT_EQUAL_INT32(0, provizio_test_create_entities_packet(&packet, 100, 200, radar_position_id,
+                                                                    provizio_radar_range_short, num_entities,
+                                                                    num_entities, provizio_test_entities_offset_step));
+
+    provizio_set_on_error(&test_provizio_on_error);
+    provizio_test_error[0] = '\0';
+    TEST_ASSERT_EQUAL_INT32(
+        PROVIZIO_E_PROTOCOL,
+        provizio_handle_entities_packet(&api_context, &packet, provizio_radar_entities_packet_size(&packet.header)));
+    TEST_ASSERT_EQUAL_STRING("provizio_check_for_too_many_entities: Too many entities received", provizio_test_error);
+    provizio_set_on_error(NULL);
+}
+
+int provizio_run_test_radar_entities(void)
+{
+    memset(provizio_test_warning, 0, sizeof(provizio_test_warning));
+    memset(provizio_test_error, 0, sizeof(provizio_test_error));
+
+    UNITY_BEGIN();
+
+    RUN_TEST(test_provizio_radar_entities_packet_size);
+    RUN_TEST(test_provizio_check_radar_entities_packet);
+    RUN_TEST(test_provizio_handle_entities_packet_warnings);
+    RUN_TEST(test_provizio_radar_entities_api_context_assign);
+    RUN_TEST(test_provizio_handle_radars_entities_packet_bad_packet);
+    RUN_TEST(test_provizio_handle_possible_radar_entities_packet_wrong_packet_size);
+    RUN_TEST(test_provizio_handle_possible_radar_entities_packet_wrong_packet_type);
+    RUN_TEST(test_provizio_handle_possible_radar_entities_packet_wrong_protocol_version);
+    RUN_TEST(test_provizio_handle_possible_radar_entities_packet_ok);
+    RUN_TEST(test_provizio_handle_possible_radars_entities_packet_ok);
+    RUN_TEST(test_provizio_handle_entities_packet_frame_indices_overflow);
+    RUN_TEST(test_provizio_handle_entities_packet_drop_obsolete_incomplete_frame);
+    RUN_TEST(test_provizio_handle_entities_packet_too_many_entities);
+    RUN_TEST(test_provizio_return_entities_frame_returns_older_first);
+    RUN_TEST(test_provizio_handle_entities_packet_empty_frame);
+    RUN_TEST(test_provizio_handle_radars_entities_packet_reuses_existing_context);
+    RUN_TEST(test_provizio_handle_radars_entities_packet_out_of_contexts);
+    RUN_TEST(test_provizio_test_next_value_handles_nonpositive_range);
+
+    return UNITY_END();
+}

--- a/test/c_99/src/test_radar_point_cloud.c
+++ b/test/c_99/src/test_radar_point_cloud.c
@@ -77,10 +77,7 @@ void test_provizio_radar_point_cloud_callback(const provizio_radar_point_cloud *
     data->last_point_clouds[0] = *point_cloud;
 }
 
-static int32_t create_test_pointcloud_packet(provizio_radar_point_cloud_packet *packet, const uint32_t frame_index,
-                                             const uint64_t timestamp, const uint16_t radar_position_id,
-                                             const uint16_t radar_range, const uint16_t total_points_in_frame,
-                                             const uint16_t num_points_in_packet)
+static void fill_packet_points(provizio_radar_point_cloud_packet *packet, const uint16_t num_points_in_packet)
 {
     const float x_meters_min = -100.0F;
     const float x_meters_max = 100.0F;
@@ -109,19 +106,6 @@ static int32_t create_test_pointcloud_packet(provizio_radar_point_cloud_packet *
     float ground_velocity = (ground_velocity_min + ground_velocity_max) * half;
     float signal_to_noise_ratio = (signal_to_noise_ratio_min + signal_to_noise_ratio_max) * half;
 
-    memset(packet, 0, sizeof(provizio_radar_point_cloud_packet));
-
-    provizio_set_protocol_field_uint16_t(&packet->header.protocol_header.packet_type,
-                                         PROVIZIO__RADAR_API_POINT_CLOUD_PACKET_TYPE);
-    provizio_set_protocol_field_uint16_t(&packet->header.protocol_header.protocol_version,
-                                         PROVIZIO__RADAR_API_POINT_CLOUD_PROTOCOL_VERSION);
-    provizio_set_protocol_field_uint32_t(&packet->header.frame_index, frame_index);
-    provizio_set_protocol_field_uint64_t(&packet->header.timestamp, timestamp);
-    provizio_set_protocol_field_uint16_t(&packet->header.radar_position_id, radar_position_id);
-    provizio_set_protocol_field_uint16_t(&packet->header.radar_range, radar_range);
-    provizio_set_protocol_field_uint16_t(&packet->header.total_points_in_frame, total_points_in_frame);
-    provizio_set_protocol_field_uint16_t(&packet->header.num_points_in_packet, num_points_in_packet);
-
 #pragma unroll(8)
     for (uint16_t j = 0; j < num_points_in_packet; ++j) // NOLINT: The loop is just fine
     {
@@ -143,6 +127,27 @@ static int32_t create_test_pointcloud_packet(provizio_radar_point_cloud_packet *
         provizio_set_protocol_field_float(&packet->radar_points[j].ground_relative_radial_velocity_m_s,
                                           ground_velocity);
     }
+}
+
+static int32_t create_test_pointcloud_packet(provizio_radar_point_cloud_packet *packet, const uint32_t frame_index,
+                                             const uint64_t timestamp, const uint16_t radar_position_id,
+                                             const uint16_t radar_range, const uint16_t total_points_in_frame,
+                                             const uint16_t num_points_in_packet)
+{
+    memset(packet, 0, sizeof(provizio_radar_point_cloud_packet));
+
+    provizio_set_protocol_field_uint16_t(&packet->header.protocol_header.packet_type,
+                                         PROVIZIO__RADAR_API_POINT_CLOUD_PACKET_TYPE);
+    provizio_set_protocol_field_uint16_t(&packet->header.protocol_header.protocol_version,
+                                         PROVIZIO__RADAR_API_POINT_CLOUD_PROTOCOL_VERSION);
+    provizio_set_protocol_field_uint32_t(&packet->header.frame_index, frame_index);
+    provizio_set_protocol_field_uint64_t(&packet->header.timestamp, timestamp);
+    provizio_set_protocol_field_uint16_t(&packet->header.radar_position_id, radar_position_id);
+    provizio_set_protocol_field_uint16_t(&packet->header.radar_range, radar_range);
+    provizio_set_protocol_field_uint16_t(&packet->header.total_points_in_frame, total_points_in_frame);
+    provizio_set_protocol_field_uint16_t(&packet->header.num_points_in_packet, num_points_in_packet);
+
+    fill_packet_points(packet, num_points_in_packet);
 
     return 0;
 }
@@ -254,6 +259,7 @@ static void test_provizio_check_radar_point_cloud_packet(void)
 
     provizio_radar_point_cloud_packet packet;
     memset(&packet, 0, sizeof(packet));
+    fill_packet_points(&packet, num_points);
 
     // Check failure due to size < sizeof(provizio_radar_api_protocol_header)
     TEST_ASSERT_EQUAL_INT32(PROVIZIO_E_PROTOCOL,
@@ -330,7 +336,7 @@ static void test_provizio_check_radar_point_cloud_packet(void)
                             provizio_handle_radar_point_cloud_packet(
                                 &api_context, &packet, provizio_radar_point_cloud_packet_size(&packet.header)));
 
-    // All check pass well
+    // All checks pass
     provizio_set_protocol_field_uint16_t(&packet.header.radar_position_id, provizio_radar_position_front_center);
     provizio_set_protocol_field_uint16_t(&packet.header.total_points_in_frame, num_points);
     TEST_ASSERT_EQUAL_INT32(0, provizio_handle_radar_point_cloud_packet(
@@ -365,6 +371,7 @@ static void test_provizio_handle_radar_point_cloud_packet_warnings(void)
     provizio_set_protocol_field_uint16_t(&packet.header.total_points_in_frame, num_points);
     provizio_set_protocol_field_uint16_t(&packet.header.num_points_in_packet, 1);
     provizio_set_protocol_field_uint16_t(&packet.header.radar_range, provizio_radar_range_medium);
+    fill_packet_points(&packet, num_points);
 
     // Send first point
     TEST_ASSERT_EQUAL_INT32(0, provizio_handle_radar_point_cloud_packet(

--- a/test/c_99/src/test_radar_points_accumulation_types.c
+++ b/test/c_99/src/test_radar_points_accumulation_types.c
@@ -16,96 +16,6 @@
 
 #include "unity/unity.h"
 
-#include <linmath.h>
-
-void test_provizio_quaternion_set_identity(void)
-{
-    provizio_quaternion quaternion = {2.0F, 3.0F, 4.0F, 5.0F}; // NOLINT Some "garbage" to make sure it gets overwritten
-    provizio_quaternion_set_identity(&quaternion);
-
-    TEST_ASSERT_EQUAL_FLOAT(1.0F, quaternion.w); // NOLINT
-    TEST_ASSERT_EQUAL_FLOAT(0.0F, quaternion.x); // NOLINT
-    TEST_ASSERT_EQUAL_FLOAT(0.0F, quaternion.y); // NOLINT
-    TEST_ASSERT_EQUAL_FLOAT(0.0F, quaternion.z); // NOLINT
-
-    vec3 in_vec = {10.0F, 100.0F, 1000.0F}; // NOLINT
-    quat in_quat = {quaternion.x, quaternion.y, quaternion.z, quaternion.w};
-    vec3 out_vec = {0, 0, 0};
-    quat_mul_vec3(out_vec, in_quat, in_vec);
-    TEST_ASSERT_EQUAL_FLOAT(in_vec[0], out_vec[0]); // NOLINT
-    TEST_ASSERT_EQUAL_FLOAT(in_vec[1], out_vec[1]); // NOLINT
-    TEST_ASSERT_EQUAL_FLOAT(in_vec[2], out_vec[2]); // NOLINT
-}
-
-void test_provizio_quaternion_set_euler_angles(void)
-{
-    provizio_quaternion quaternion = {2.0F, 3.0F, 4.0F, 5.0F}; // NOLINT Some "garbage" to make sure it gets overwritten
-
-    vec3 in_vec = {5.0F, 10.0F, 30.0F}; // NOLINT
-
-    // Rotate around X
-    {
-        provizio_quaternion_set_euler_angles((float)M_PI_2, 0.0F, 0.0F, &quaternion);
-        quat in_quat = {quaternion.x, quaternion.y, quaternion.z, quaternion.w};
-        vec3 out_vec = {0, 0, 0};
-        quat_mul_vec3(out_vec, in_quat, in_vec);
-        TEST_ASSERT_EQUAL_FLOAT(5.0F, out_vec[0]);   // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(-30.0F, out_vec[1]); // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(10.0F, out_vec[2]);  // NOLINT
-    }
-
-    // Rotate around Y
-    {
-        provizio_quaternion_set_euler_angles(0.0F, (float)M_PI_2, 0.0F, &quaternion);
-        quat in_quat = {quaternion.x, quaternion.y, quaternion.z, quaternion.w};
-        vec3 out_vec = {0, 0, 0};
-        quat_mul_vec3(out_vec, in_quat, in_vec);
-        TEST_ASSERT_EQUAL_FLOAT(30.0F, out_vec[0]); // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(10.0F, out_vec[1]); // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(-5.0F, out_vec[2]); // NOLINT
-    }
-
-    // Rotate around Z
-    {
-        provizio_quaternion_set_euler_angles(0.0F, 0.0F, (float)M_PI_2, &quaternion);
-        quat in_quat = {quaternion.x, quaternion.y, quaternion.z, quaternion.w};
-        vec3 out_vec = {0, 0, 0};
-        quat_mul_vec3(out_vec, in_quat, in_vec);
-        TEST_ASSERT_EQUAL_FLOAT(-10.0F, out_vec[0]); // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(5.0F, out_vec[1]);   // NOLINT
-        TEST_ASSERT_EQUAL_FLOAT(30.0F, out_vec[2]);  // NOLINT
-    }
-}
-
-void test_provizio_quaternion_is_valid_rotation(void)
-{
-    // Invalid: zero
-    {
-        const provizio_quaternion quaternion = {0, 0, 0, 0};
-        TEST_ASSERT_EQUAL(0, provizio_quaternion_is_valid_rotation(&quaternion));
-    }
-
-    // Invalid: garbage
-    {
-        const provizio_quaternion quaternion = {2.0F, 3.0F, 4.0F, 5.0F};
-        TEST_ASSERT_EQUAL(0, provizio_quaternion_is_valid_rotation(&quaternion));
-    }
-
-    // Valid: Identity
-    {
-        provizio_quaternion quaternion = {2.0F, 3.0F, 4.0F, 5.0F}; // NOLINT
-        provizio_quaternion_set_identity(&quaternion);
-        TEST_ASSERT_NOT_EQUAL(0, provizio_quaternion_is_valid_rotation(&quaternion));
-    }
-
-    // Valid: Rotation
-    {
-        provizio_quaternion quaternion = {2.0F, 3.0F, 4.0F, 5.0F}; // NOLINT
-        provizio_quaternion_set_euler_angles((float)M_PI_2, (float)M_PI_4, (float)M_E, &quaternion);
-        TEST_ASSERT_NOT_EQUAL(0, provizio_quaternion_is_valid_rotation(&quaternion));
-    }
-}
-
 void test_provizio_enu_distance(void)
 {
     {
@@ -142,9 +52,6 @@ int provizio_run_test_radar_points_accumulation_types(void)
 {
     UNITY_BEGIN();
 
-    RUN_TEST(test_provizio_quaternion_set_identity);
-    RUN_TEST(test_provizio_quaternion_set_euler_angles);
-    RUN_TEST(test_provizio_quaternion_is_valid_rotation);
     RUN_TEST(test_provizio_enu_distance);
 
     return UNITY_END();

--- a/test/cpp_14/src/smoketest.cpp
+++ b/test/cpp_14/src/smoketest.cpp
@@ -32,9 +32,11 @@
 #include "provizio/radar_api/radar_points_accumulation.h"
 #include "provizio/socket.h"
 
+// Different versions of clang-tidy have different preferences to static vs anonymous namespace, we go with anonymous
+// namespace plus NOLINT to make it pass clean all anyways.
 namespace
 {
-    std::unique_ptr<void, std::function<void(void *)>> make_guard(const PROVIZIO__SOCKET sock)
+    std::unique_ptr<void, std::function<void(void *)>> make_guard(const PROVIZIO__SOCKET sock) // NOLINT
     {
         // LCOV_EXCL_START: lcov isn't great at handling C++ lambdas
         return std::unique_ptr<void, std::function<void(void *)>>{
@@ -49,7 +51,7 @@ namespace
         // LCOV_EXCL_STOP
     }
 
-    std::unique_ptr<void, std::function<void(void *)>> make_guard(provizio_radar_api_connection &connection)
+    std::unique_ptr<void, std::function<void(void *)>> make_guard(provizio_radar_api_connection &connection) // NOLINT
     {
         // LCOV_EXCL_START: lcov isn't great at handling C++ lambdas
         return std::unique_ptr<void, std::function<void(void *)>>{
@@ -65,7 +67,7 @@ namespace
     }
 
     template <typename functor>
-    void callback_wrapper(const provizio_radar_point_cloud *point_cloud,
+    void callback_wrapper(const provizio_radar_point_cloud *point_cloud, // NOLINT
                           struct provizio_radar_point_cloud_api_context *context)
     {
         (*static_cast<functor *>(context->user_data))(point_cloud, context);
@@ -215,7 +217,8 @@ int main(int argc, char *argv[])
 
             provizio_radar_api_connection connection;
             const auto connection_guard = make_guard(connection);
-            error_code = provizio_open_radar_connection(port_number, timeout_ns, 1, api_context.get(), &connection);
+            error_code =
+                provizio_open_radar_connection(port_number, timeout_ns, 1, api_context.get(), nullptr, &connection);
             if (error_code != 0)
             {
                 // LCOV_EXCL_START: Shouldn't happen

--- a/test/include/test_entities_callbacks.h
+++ b/test/include/test_entities_callbacks.h
@@ -1,0 +1,30 @@
+// Copyright 2025 Provizio Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDE_TEST_ENTITIES_CALLBACKS
+#define INCLUDE_TEST_ENTITIES_CALLBACKS
+
+#include "provizio/radar_api/entities.h"
+
+#define PROVIZIO__TEST_CALLBACK_DATA_NUM_ENTITIES_FRAMES 4
+typedef struct test_provizio_radar_entities_callback_data
+{
+    int32_t called_times;
+    provizio_radar_entities_frame last_entities_frames[PROVIZIO__TEST_CALLBACK_DATA_NUM_ENTITIES_FRAMES];
+} test_provizio_radar_entities_callback_data;
+
+void test_provizio_radar_entities_callback(const provizio_radar_entities_frame *entities_frame,
+                                           provizio_radar_entities_api_context *context);
+
+#endif // INCLUDE_TEST_ENTITIES_CALLBACKS

--- a/test/include/test_entities_helpers.h
+++ b/test/include/test_entities_helpers.h
@@ -15,6 +15,7 @@
 #ifndef INCLUDE_TEST_ENTITIES_HELPERS
 #define INCLUDE_TEST_ENTITIES_HELPERS
 
+#include <assert.h>
 #include <math.h>
 #include <string.h>
 
@@ -43,6 +44,8 @@ static inline int32_t provizio_test_create_entities_packet(provizio_radar_entiti
                                                            uint16_t radar_range, uint16_t total_entities_in_frame,
                                                            uint16_t num_entities_in_packet, float x_offset)
 {
+    assert(num_entities_in_packet <= PROVIZIO__MAX_RADAR_ENTITIES_PER_UDP_PACKET);
+
     const float x_meters_min = -50.0F;
     const float x_meters_max = 50.0F;
     const float x_meters_step = 3.5F;
@@ -59,8 +62,11 @@ static inline int32_t provizio_test_create_entities_packet(provizio_radar_entiti
     const float ground_velocity_max = 12.0F;
     const float ground_velocity_step = 2.25F;
     const float orientation_min = -1.0F;
-    const float orientation_max = 1.0F;
+    const float orientation_max = 2.0F;
     const float orientation_step = 0.19F;
+    const float size_min = 0.25F;
+    const float size_max = 20.0F;
+    const float size_step = 1.6F;
     const float half = 0.5F;
 
     float x_meters = (x_meters_min + x_meters_max) * half + x_offset;
@@ -71,7 +77,10 @@ static inline int32_t provizio_test_create_entities_packet(provizio_radar_entiti
     float orientation_w = (orientation_min + orientation_max) * half;
     float orientation_x = orientation_w * half;
     float orientation_y = -orientation_w * half;
-    float orientation_z = orientation_w;
+    float orientation_z = -orientation_w;
+    float size_x = (size_min + size_max) * half;
+    float size_y = size_x - size_step;
+    float size_z = size_x + size_step;
 
     memset(packet, 0, sizeof(provizio_radar_entities_packet));
 
@@ -103,6 +112,9 @@ static inline int32_t provizio_test_create_entities_packet(provizio_radar_entiti
         orientation_x = provizio_test_next_value(orientation_x, orientation_min, orientation_max, orientation_step);
         orientation_y = provizio_test_next_value(orientation_y, orientation_min, orientation_max, orientation_step);
         orientation_z = provizio_test_next_value(orientation_z, orientation_min, orientation_max, orientation_step);
+        size_x = provizio_test_next_value(size_x, size_min, size_max, size_step);
+        size_y = provizio_test_next_value(size_y, size_min, size_max, size_step);
+        size_z = provizio_test_next_value(size_z, size_min, size_max, size_step);
 
         provizio_set_protocol_field_uint32_t(&entity->entity_id, (uint32_t)j + 1U);
         provizio_set_protocol_field_float(&entity->x_meters, x_meters);
@@ -114,6 +126,9 @@ static inline int32_t provizio_test_create_entities_packet(provizio_radar_entiti
         provizio_set_protocol_field_float(&entity->orientation.x, orientation_x);
         provizio_set_protocol_field_float(&entity->orientation.y, orientation_y);
         provizio_set_protocol_field_float(&entity->orientation.z, orientation_z);
+        provizio_set_protocol_field_float(&entity->size.x_meters, size_x);
+        provizio_set_protocol_field_float(&entity->size.y_meters, size_y);
+        provizio_set_protocol_field_float(&entity->size.z_meters, size_z);
         provizio_set_protocol_field_uint8_t(&entity->entity_class,
                                             (uint8_t)((j % (provizio_entity_class_obstacle + 1)) + 1));
         provizio_set_protocol_field_uint8_t(&entity->entity_confidence, (uint8_t)(50 + j));

--- a/test/include/test_entities_helpers.h
+++ b/test/include/test_entities_helpers.h
@@ -1,0 +1,127 @@
+// Copyright 2025 Provizio Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDE_TEST_ENTITIES_HELPERS
+#define INCLUDE_TEST_ENTITIES_HELPERS
+
+#include <math.h>
+#include <string.h>
+
+#include "provizio/radar_api/entities.h"
+#include "provizio/radar_api/radar_ranges.h"
+#include "provizio/util.h"
+
+static inline float provizio_test_next_value(float current, float min, float max, float step)
+{
+    const float range = max - min;
+    if (range <= 0.0F)
+    {
+        return min;
+    }
+
+    float next = current + step;
+    while (next >= max)
+    {
+        next = min + fmodf(next - min, range);
+    }
+    return next;
+}
+
+static inline int32_t provizio_test_create_entities_packet(provizio_radar_entities_packet *packet, uint32_t frame_index,
+                                                           uint64_t timestamp, uint16_t radar_position_id,
+                                                           uint16_t radar_range, uint16_t total_entities_in_frame,
+                                                           uint16_t num_entities_in_packet, float x_offset)
+{
+    const float x_meters_min = -50.0F;
+    const float x_meters_max = 50.0F;
+    const float x_meters_step = 3.5F;
+    const float y_meters_min = -20.0F;
+    const float y_meters_max = 20.0F;
+    const float y_meters_step = 1.3F;
+    const float z_meters_min = -5.0F;
+    const float z_meters_max = 15.0F;
+    const float z_meters_step = 0.73F;
+    const float radar_velocity_min = -15.0F;
+    const float radar_velocity_max = 25.0F;
+    const float radar_velocity_step = 4.0F;
+    const float ground_velocity_min = -10.0F;
+    const float ground_velocity_max = 12.0F;
+    const float ground_velocity_step = 2.25F;
+    const float orientation_min = -1.0F;
+    const float orientation_max = 1.0F;
+    const float orientation_step = 0.19F;
+    const float half = 0.5F;
+
+    float x_meters = (x_meters_min + x_meters_max) * half + x_offset;
+    float y_meters = (y_meters_min + y_meters_max) * half;
+    float z_meters = (z_meters_min + z_meters_max) * half;
+    float radar_velocity = (radar_velocity_min + radar_velocity_max) * half;
+    float ground_velocity = (ground_velocity_min + ground_velocity_max) * half;
+    float orientation_w = (orientation_min + orientation_max) * half;
+    float orientation_x = orientation_w * half;
+    float orientation_y = -orientation_w * half;
+    float orientation_z = orientation_w;
+
+    memset(packet, 0, sizeof(provizio_radar_entities_packet));
+
+    provizio_set_protocol_field_uint16_t(&packet->header.protocol_header.packet_type,
+                                         PROVIZIO__RADAR_API_ENTITIES_PACKET_TYPE);
+    provizio_set_protocol_field_uint16_t(&packet->header.protocol_header.protocol_version,
+                                         PROVIZIO__RADAR_API_ENTITY_PROTOCOL_VERSION);
+    provizio_set_protocol_field_uint32_t(&packet->header.frame_index, frame_index);
+    provizio_set_protocol_field_uint64_t(&packet->header.timestamp, timestamp);
+    provizio_set_protocol_field_uint16_t(&packet->header.radar_position_id, radar_position_id);
+    provizio_set_protocol_field_uint16_t(&packet->header.total_entities_in_frame, total_entities_in_frame);
+    provizio_set_protocol_field_uint16_t(&packet->header.num_entities_in_packet, num_entities_in_packet);
+    provizio_set_protocol_field_uint16_t(&packet->header.radar_range, radar_range == provizio_radar_range_unknown
+                                                                          ? provizio_radar_range_medium
+                                                                          : radar_range);
+
+    for (uint16_t j = 0; j < num_entities_in_packet; ++j)
+    {
+        provizio_radar_entity *entity = &packet->radar_entities[j];
+
+        x_meters = provizio_test_next_value(x_meters, x_meters_min + x_offset, x_meters_max + x_offset, x_meters_step);
+        y_meters = provizio_test_next_value(y_meters, y_meters_min, y_meters_max, y_meters_step);
+        z_meters = provizio_test_next_value(z_meters, z_meters_min, z_meters_max, z_meters_step);
+        radar_velocity =
+            provizio_test_next_value(radar_velocity, radar_velocity_min, radar_velocity_max, radar_velocity_step);
+        ground_velocity =
+            provizio_test_next_value(ground_velocity, ground_velocity_min, ground_velocity_max, ground_velocity_step);
+        orientation_w = provizio_test_next_value(orientation_w, orientation_min, orientation_max, orientation_step);
+        orientation_x = provizio_test_next_value(orientation_x, orientation_min, orientation_max, orientation_step);
+        orientation_y = provizio_test_next_value(orientation_y, orientation_min, orientation_max, orientation_step);
+        orientation_z = provizio_test_next_value(orientation_z, orientation_min, orientation_max, orientation_step);
+
+        provizio_set_protocol_field_uint32_t(&entity->entity_id, (uint32_t)j + 1U);
+        provizio_set_protocol_field_float(&entity->x_meters, x_meters);
+        provizio_set_protocol_field_float(&entity->y_meters, y_meters);
+        provizio_set_protocol_field_float(&entity->z_meters, z_meters);
+        provizio_set_protocol_field_float(&entity->radar_relative_radial_velocity_m_s, radar_velocity);
+        provizio_set_protocol_field_float(&entity->ground_relative_radial_velocity_m_s, ground_velocity);
+        provizio_set_protocol_field_float(&entity->orientation.w, orientation_w);
+        provizio_set_protocol_field_float(&entity->orientation.x, orientation_x);
+        provizio_set_protocol_field_float(&entity->orientation.y, orientation_y);
+        provizio_set_protocol_field_float(&entity->orientation.z, orientation_z);
+        provizio_set_protocol_field_uint8_t(&entity->entity_class,
+                                            (uint8_t)((j % (provizio_entity_class_obstacle + 1)) + 1));
+        provizio_set_protocol_field_uint8_t(&entity->entity_confidence, (uint8_t)(50 + j));
+        provizio_set_protocol_field_uint8_t(&entity->entity_class_confidence, (uint8_t)(60 + j));
+        provizio_set_protocol_field_uint8_t(&entity->reserved, 0);
+    }
+
+    return 0;
+}
+
+#endif // INCLUDE_TEST_ENTITIES_HELPERS


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces radar Entities protocol and API integrated into UDP receive flow, extracts quaternion utilities, and updates README and tests accordingly.
> 
> - **Core/API**:
>   - Add `radar_entities` API (`include/provizio/radar_api/entities.h`, `src/entities.c`) with packet/frame structs, handlers, and contexts.
>   - Extend `provizio_radar_api_connection` to hold entities contexts; update `provizio_open_radar_connection` and `provizio_open_radars_connection` signatures to accept entities contexts; `provizio_radar_api_receive_packet` now dispatches entities packets.
>   - Add `include/provizio/quaternion.h` and `src/quaternion.c`; remove quaternion defs from `radar_points_accumulation_types` and use shared header.
> - **Protocol/Docs**:
>   - Define `PROVIZIO__RADAR_API_ENTITIES_PACKET_TYPE (5)` and entities packet format; document in `README.md` with usage examples (live/replay).
>   - Clarify timestamps use Unix Epoch; add macOS broadcast note in range APIs.
> - **Build**:
>   - Update `CMakeLists.txt` to compile new sources (`src/quaternion.c`, `src/entities.c`).
> - **Tests**:
>   - Add C tests for entities (`test_radar_entities.c`) and quaternion (`test_quaternion.c`); integrate into test runner.
>   - Update core/point-cloud tests and C++ smoketest for new function signatures and helpers.
> - **Misc**:
>   - Minor fixes/cleanups (duplication checks, variable names, size calculations, error logging, optional `IP_ONESBCAST`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec54b730cd59b13cc1758194d36a2f7dd5ad72ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->